### PR TITLE
`diff-containers`: Remove `Values` and `Keys` newtypes, use `Map` and `Set` instead

### DIFF
--- a/diff-containers/diff-containers.cabal
+++ b/diff-containers/diff-containers.cabal
@@ -48,6 +48,7 @@ test-suite test
   other-modules:      Test.Data.Map.Diff.Strict
 
   build-depends:      base              >=4.9 && <4.17
+                    , containers
                     , diff-containers
                     , nonempty-containers
                     , simple-semigroupoids

--- a/diff-containers/test/Test/Data/Map/Diff/Strict.hs
+++ b/diff-containers/test/Test/Data/Map/Diff/Strict.hs
@@ -9,6 +9,7 @@
 module Test.Data.Map.Diff.Strict (tests) where
 
 import           Data.Foldable (foldl')
+import           Data.Map.Strict (Map)
 import           Data.Maybe
 import           Data.Proxy (Proxy (Proxy))
 import           Data.Sequence.NonEmpty (NESeq (..))
@@ -48,7 +49,22 @@ tests = testGroup "Data.Map.Diff.Strict" [
           testSemigroupoidLaws
         , testGroupoidLaws
         ]
+    , testProperty "prop_diffThenApply @(Smaller Int)" $
+        prop_diffThenApply @(Smaller Int) @(Smaller Int)
+    , testProperty "prop_diffThenApply @Int" $
+        prop_diffThenApply @Int @Int
     ]
+
+{------------------------------------------------------------------------------
+  Simple properties
+------------------------------------------------------------------------------}
+
+prop_diffThenApply ::
+     (Show k, Show v, Ord k, Eq v)
+  => Map k v
+  -> Map k v
+  -> Property
+prop_diffThenApply m1 m2 = applyDiff m1 (diff m1 m2) === m2
 
 {------------------------------------------------------------------------------
   Preconditions


### PR DESCRIPTION
The `Values` and `Keys` newtypes are `ourboros-consensus` specific, so we should use the more widely used `Map` and `Set` types instead. This makes the `diff-containers` package more general purpose.