### PR TITLE
`diff-containers`: Hide unsafe definitions behind a safe interface

### DIFF
--- a/diff-containers/diff-containers.cabal
+++ b/diff-containers/diff-containers.cabal
@@ -19,7 +19,8 @@ library
   default-language:   Haskell2010
   hs-source-dirs:     src
 
-  exposed-modules:    Data.Map.Diff.Strict.Internal
+  exposed-modules:    Data.Map.Diff.Strict
+                      Data.Map.Diff.Strict.Internal
   other-modules:      Data.Sequence.NonEmpty.Extra
 
   build-depends:      base              >=4.9 && <4.17

--- a/diff-containers/diff-containers.cabal
+++ b/diff-containers/diff-containers.cabal
@@ -19,7 +19,7 @@ library
   default-language:   Haskell2010
   hs-source-dirs:     src
 
-  exposed-modules:    Data.Map.Diff.Strict
+  exposed-modules:    Data.Map.Diff.Strict.Internal
   other-modules:      Data.Sequence.NonEmpty.Extra
 
   build-depends:      base              >=4.9 && <4.17

--- a/diff-containers/src/Data/Map/Diff/Strict.hs
+++ b/diff-containers/src/Data/Map/Diff/Strict.hs
@@ -1,0 +1,33 @@
+module Data.Map.Diff.Strict (
+    -- * Types
+    Diff
+  , DiffEntry (..)
+    -- * Conversion
+  , keysSet
+    -- * Construction
+  , diff
+    -- ** Maps
+  , fromMap
+  , fromMapDeletes
+  , fromMapInserts
+    -- ** Lists
+  , fromList
+  , fromListDeletes
+  , fromListInserts
+    -- * Query
+    -- ** Size
+  , null
+  , size
+    -- * Applying diffs
+  , applyDiff
+  , applyDiffForKeys
+    -- * Folds and traversals
+  , foldMapDiffEntry
+  , traverseDiffEntryWithKey_
+    -- * Filter
+  , filterOnlyKey
+  ) where
+
+import           Prelude hiding (null)
+
+import           Data.Map.Diff.Strict.Internal

--- a/diff-containers/src/Data/Map/Diff/Strict/Internal.hs
+++ b/diff-containers/src/Data/Map/Diff/Strict/Internal.hs
@@ -10,7 +10,7 @@
 {-# LANGUAGE ScopedTypeVariables        #-}
 {-# LANGUAGE ViewPatterns               #-}
 
-module Data.Map.Diff.Strict (
+module Data.Map.Diff.Strict.Internal (
     Diff (..)
   , DiffEntry (..)
   , DiffHistory (..)

--- a/diff-containers/test/Test/Data/Map/Diff/Strict.hs
+++ b/diff-containers/test/Test/Data/Map/Diff/Strict.hs
@@ -18,7 +18,7 @@ import qualified Data.Sequence.NonEmpty as NESeq
 import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.QuickCheck
 
-import           Data.Map.Diff.Strict
+import           Data.Map.Diff.Strict.Internal
 
 import           Data.Semigroupoid.Simple.Auto
 import           Data.Semigroupoid.Simple.Laws


### PR DESCRIPTION
The first commit in this PR moves all definitions from `Data.Map.Diff.Strict` to `Data.Map.Diff.Strict.Internal`. The second commits re-exports safe definitions from `Data.Map.Diff.Strict.Internal` in `Data.Map.Diff.Strict`. Some additional safe definitions are added to `Data.Map.Diff.Strict.Internal` (and subsequently re-exported in `Data.Map.Diff.Strict`) that prevent downstream code in `ouroboros-consensus`-related package from having to import the internal module. Examples: `size`, `keysSet`, `filterOnlyKey`, `fromMap*` and `fromList*`.