### PR TITLE
Compute the effect (in terms of change in size) of applying a `Diff` to a `Data.Map`

### DIFF
--- a/diff-containers/src/Data/Map/Diff/Strict.hs
+++ b/diff-containers/src/Data/Map/Diff/Strict.hs
@@ -43,6 +43,7 @@ module Data.Map.Diff.Strict (
     -- ** Size
   , null
   , size
+  , sizeEffect
     -- ** Positivity and normality
   , isNormal
   , isPositive

--- a/diff-containers/src/Data/Map/Diff/Strict/Internal.hs
+++ b/diff-containers/src/Data/Map/Diff/Strict/Internal.hs
@@ -217,7 +217,7 @@ size (Diff m) = Map.size m
 -- | @'sizeEffect' d@ returns a number @n@: the number of inserts minus the
 -- number of deletes for a diff @d@.
 --
--- Applying @d@ to a 'Map' should increase the size of the 'Map' by this number,
+-- Applying @d@ to a 'Map' should increase the size of the 'Map' by @n@,
 -- but only if @d@ does not delete a key that does not exist in the 'Map', and
 -- @d@ does not insert a key that already exists in the 'Map'.
 --


### PR DESCRIPTION
Motivated by [ouroboros-network#39](https://github.com/input-output-hk/ouroboros-consensus/issues/57). Computing the change in size after applying a diff helps us in estimating the size of the UTxO in ouroboros-consensus. This is because in the UTxO HD era, information about the size of the UTxO is not readily available anymore in memory, but has to be computed from on-disk and in-memory information, the latter of which consists largely of diffs.
