### PR TITLE
Major rework: use `Cancellative` instead of `Group` properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,7 @@
 
 # anti-diffs
 
-Packages for performant sequences of `Data.Map` differences.
-
-We follow processes and guidelines as established by the Consensus team at IOG.
-A nice starting point for reading `ouroboros-consensus` documentation is
-[ouroboros-network/ouroboros-consensus/README.md](
-https://github.com/input-output-hk/ouroboros-network/blob/master/ouroboros-consensus/README.md).
-
+Packages for sequences of `Data.Map` differences.
 
 ## Usage
 

--- a/diff-containers/CHANGELOG.md
+++ b/diff-containers/CHANGELOG.md
@@ -1,5 +1,19 @@
+## Next version
 
-<a id='changelog-0.1.0.0'></a>
+### Breaking changes
+
+* Make diffs a cancellative monoid instead of a group. Amongst others, this
+  change removes the need for preconditions and invariants relating to normality
+  and positivity, which greatly simplifies the code and makes it more ergonomic,
+  while still allowing a (more restrictive) type of diff subtraction. Changes
+  include:
+  * Remove the `Group` instance for diffs.
+  * Add class instances for reductive and cancellative semigroup classes.
+  * Remove predicates related to normality and positivity.
+  * Remove unsafe constructors for `DiffEntry`.
+  * Make `applyDiff` and `applyDiffForKeys` total.
+  * Remove `unsafeApplyDiff` and `unsafeApplyDiffForKeys`.
+
 ## 0.1.0.0 — 2023-02-16
 
 First release

--- a/diff-containers/README.md
+++ b/diff-containers/README.md
@@ -7,48 +7,27 @@ there is only one such implemented difference datatype for `Data.Map.Strict`.
 
 A difference datatype for maps is defined and implemented in the
 `Data.Map.Diff.Strict` module. A key property of our definition of diffs is that
-diffs can not only be combined/summed, they can also be inverted and summed
-together, which facilitates *subtraction* of diffs. Our definition of diffs is
-not only a [`Semigroup`](https://en.wikipedia.org/wiki/Semigroup#Definition) and
-a [`Monoid`](https://en.wikipedia.org/wiki/Monoid#Definition), it is also a
-[`Group`](https://en.wikipedia.org/wiki/Group_(mathematics)#Definition).
+diffs can not only be combined/summed, they can also be subtracted. Our
+definition of diffs is not only a
+[semigroup](https://en.wikipedia.org/wiki/Semigroup#Definition) and a
+[monoid](https://en.wikipedia.org/wiki/Monoid#Definition), it is also a
+[cancellative semigroup](https://en.wikipedia.org/wiki/Cancellative_semigroup).
+Note that diffs are not a commutative semigroup.
 
-The goals for our definition of diffs are twofold:
-1. Provide definitions that adhere to the type class laws for `Semigroup`,
-   `Monoid` and `Group`.
-2. Applying diffs to maps should have a sound semantics: if we apply a positive
-   diff (see Section [4) Applying diffs with inverses: positivity and
-   normality](#4-applying-diffs-with-inverses-positivity-and-normality)), then
-   the resulting map is correct.
+### Simple overview
 
-An overview of the sections in this document:
-
-* Section [1) High-level overview](#high-level-overview) provides a high-level
-  overview of diffs, how to create them, and how to apply them.
-* Section [2) A first attempt at implementing
-  diffs](#2-a-first-attempt-at-implementing-diffs) describes a straightforward
-  way to implement diffs, and where this goes wrong if we try to define a
-  `Group` instance.
-* Section [3) Implementing diffs with
-  inverses](#3-implementing-diffs-with-inverses) describes how we implement
-  diffs to facilitate a `Group` instance.
-* Section [4) Applying diffs with inverses: positivity and
-  normality](#4-applying-diffs-with-inverses-positivity-and-normality) describes
-  how applying diffs can fail, but which can be solved by guaranteeing the
-  positivity and normality properties.
-
-### 1) High-level overview
-
-For each of the key-value pairs in a map, the difference type will keep track of
-whether a value is to be inserted or deleted:
+A difference type keeps track of whether a value is to be inserted or deleted at
+a specific key. At the same time, we also keep track of the history of changes
+for specific keys using a diff history, the right-most element of the history
+being the latest change. As we will see later, this is a prerequisite for diffs
+to be a cancellative semigroup.
 
 ```haskell
-newtype Diff k v = Diff {- omitted -}
-
+newtype Diff k v = Diff (Map k (NEDiffHistory v))
+newtype NEDiffHistory v = NEDiffHistory { getNEDiffHistory :: NESeq (DiffEntry v) }
 data DiffEntry v =
-    Insert !v
-  | Delete !v
-  {- omitted for now -}
+      Insert !v
+    | Delete !v
 ```
 
 One method of constructing a diff is to compute the difference between two maps.
@@ -65,195 +44,62 @@ Diffs can be applied to maps to obtain new maps. For diffs constructed using
 `diff`, the following `property` also holds:
 
 ```haskell
-unsafeApplyDiff :: Ord k => Map k v -> Diff k v -> Map k v
+applyDiff :: Ord k => Map k v -> Diff k v -> Map k v
 
 property :: Map k v -> Map k v -> Bool
-property = unsafeApplyDiff m1 (diff m1 m2) == m2
+property = applyDiff m1 (diff m1 m2) == m2
 ```
 
-### 2) A first attempt at implementing diffs
+### Diffs are cancellative monoids
 
-A straightfoward to represent differences on maps is to keep track of the most
-recent change for each key in the map.
+A straightfoward way to represent differences on maps is to keep track of the
+most recent change for each key in the map.
 
 ```haskell
 type Diff_ k v = Diff_ (Map k (Delta_ v))
-data Delta_ = Insert_ !v | Delete_ !v
+data Delta_ =
+    I !v -- ^ Insert
+  | D !v -- ^ Delete
 ```
 
-Diffs can then be summed (or combined/`mappend`ed) through a
-`Semigroup`/`Monoid` instance that behaves like a pair-wise `Last` monoid.
+Diffs can then be summed through a `Semigroup`/`Monoid` instance that behaves
+like a pair-wise `Last` monoid.
 
 ```haskell
-   fromList [(1, Insert_ 54), (2, Delete_ 42)                ]
-<> fromList [                 (2, Insert_ 17), (3, Delete_ 1)]
-== fromList [(1, Insert_ 54), (2, Insert_ 17), (3, Delete_ 1)]
+   Diff (fromList [(1, I 54), (2, D 42)          ])
+<> Diff (fromList [           (2, I 17), (3, D 1)])
+== Diff (fromList [(1, I 54), (2, I 17), (3, D 1)])
 ```
 
-What if we want to remove diffs, i.e. through subtraction provided by a `Group`
-instance? In the current definition, there is no way to recover information
-about previous changes, since we only have the last/most recent change. In
-particular, we would like to be able to have the following, where `(~~)` is a
-subtraction operator provided by `Data.Group`.
+What if we want to undo changes in a diff, like undoing the most recent `I 17`
+change to have `D 42` once again? In this simple definition, there is no way to
+recover information about previous changes, since we only track the last/most
+recent change, so we are stuck.
+
+The trick is to store a *history* of deltas (`DiffEntry`) for each key. When we
+undo changes, we remove deltas from histories. The way in which this
+"subtraction" of deltas is facilitated is by defining an instance for the
+`LeftReductive`/`LeftCancellative` and `RightReductive`/`RightCancellative`
+classes by implementing the `stripPrefix` and `stripSuffix` functions. Consider
+this simplified example of stripping prefixes/suffixes for diff histories
+(printed as lists).
 
 ```haskell
-  (fromList [(1, Insert_ 54), (2, Delete_ 42)                ]
-<> fromList [                 (2, Insert_ 17), (3, Delete_ 1)])
-~~ fromList [                 (2, Insert_ 17), (3, Delete_ 1)]
-== fromList [(1, Insert_ 54), (2, Insert_ 17), (3, Delete_ 1)]
-~~ fromList [                 (2, Insert_ 17), (3, Delete_ 1)]
-== fromList [(1, Insert_ 54), (2, Delete_ 42)                ]
+h1 = [D 42]
+h2 = [I 17]
+h3 = stripSuffix h2 (h1 <> h2) == Just h1
+h4 = stripPrefix h1 (h1 <> h2) == Just h2
 ```
 
-If we only consider the diff with respect to key `2`, how could we achieve
-`Insert_ 17 ~~ Insert_ 17 == Delete_ 42` if we have no idea that `Delete_ 42`
-was the last delta before we summed with `Insert_ 17`? We throw away this
-information, so there's no way to define subtraction correctly.
-
-Please note that the parenthesisation should not matter for a correct
-implementation of subtraction: `(~~)` is an alias for `\x y -> x <> invert y`,
-where `invert` is provided by `Data.Group` as well, and `(<>)` *should be*
-associative.
-
-### 3) Diffs with inverses
-
-The trick is to store a *history* of deltas for each key. When we subtract diffs
-from one another, we remove deltas from histories. How exactly deltas are
-removed, we will touch upon later. For now, these are the (simplified) types
-that make up a diff:
+Stripping prefixes/suffixes of diffs follows from pairwise stripping
+prefixes/suffixes of diff histories. As such, diffs have `LeftReductive`,
+`LeftCancellative`, `RightReductive` and `RightCancellative` instances as well.
+See this example:
 
 ```haskell
--- Note: this is a simplified representation. In reality, we enforce statically
--- that diff histories in a @'Diff'@ are non-empty.
-newtype Diff k v = Diff (Map k (DiffHistory v))
-
-newtype DiffHistory v = DiffHistory { getDiffHistory :: Seq (DiffEntry v) }
-
-data DiffEntry v =
-    Insert !v
-  | Delete !v
-  {- omitted for now -}
+let a = Diff (fromList [(1, [I 54]), (2, [D 42])            ])
+    b = Diff (fromList [             (2, [I 17]), (3, [D 1])])
+    c = Diff (fromList [             (2, [I 17])            ])
+    d = Diff (fromList [(1, [I 54]), (2, [D 42]), (3, [D 1])])
+in  a <> b `stripSuffix` c == d
 ```
-
-The way in which subtraction is facilitated is by implementing the `invert`
-method in a `Group` instance. As a consequence, not only do we have to add
-inverses for diffs, diff histories and diff entries, we must also define how
-these inverses are handled by summing.
-
-First, we start by adding inverse elements to the definition of `DiffEntry`. One
-may think `Insert` and `Delete` are already inverses of one another, and that
-would be correct in terms of adhering to the type class laws, but it would have
-adverse effects on the semantics of applying diffs to maps. Consider what would
-happen if we were to consider `Insert` and `Delete` inverses in the following
-example. Ignore diff histories for now:
-
-```haskell
-d1 = fromList [(0, Delete 17)]
-d2 = fromList [(0, Insert 42)]
-d3 = d1 <> d2 = fromList []
-```
-
-Applying `d3` to a map would behave like the identity function. Applying `d1`
-and `d2` consecutively would not behave like the identity function, as it would
-map `0` to `42`. Through some abuse of the definition of distributivity, we can
-say that applying diffs does not distribute over the summing of diffs.
-
-Instead, we add explicit inverse constructors for both `Insert` and `Delete`. We
-do not make `Semigroup`/`Monoid`/`Group` instances for diff entries, however. We
-shall see that we only need these 4 constructors in order to provide the
-instances for diff histories.
-
-```haskell
-data DiffEntry v =
-    Insert !v
-  | Delete !v
-  | UnsafeAntiInsert !v -- ^ Unsafe!
-  | UnsafeAntiDelete !v -- ^ Unsafe!
-```
-
-The inverse constructors are deemed unsafe in the sense that they should not be
-explicitly constructed or matched on without dire consequences, because it will
-easily violate the positivity and normality properties that are discussed in
-[section 4](#4-applying-diffs-with-inverses-positivity-and-normality).
-
-Inverse diff entries will *cancel out* when we sum diff histories. For example:
-
-```haskell
-h1 = fromList [Insert 1, UnsafeAntiDelete 2, UnsafeAntiInsert 3]
-h2 = fromList [Delete 2, Insert 3, Insert 3]
-h3 = h1 <> h2 = [Insert 1, Delete 2, Insert 3]
-```
-
-How do we invert diff histories? The type class laws that a `Group` instance
-should adhere to give us a clue:
-
-```haskell
--- left inverse
-a <> invert a == mempty
--- right inverse
-invert a <> a == mempty
-```
-
-Given that inverse diff entries cancel each other out, inverting a diff history should invert all diff entries and reverse their order. See this example:
-
-```haskell
-h        = fromList [Insert 1, Delete 2, Delete 3, Insert 4]
-invert h = fromList [UnsafeAntiInsert 4, UnsafeAntiDelete 3, UnsafeAntiDelete 2, UnsafeAntiInsert 1]
-
-invert h <> h == mempty
-h <> invert h == mempty
-```
-
-Summing of diffs follows from pairwise summing the inner diff histories.
-Inverting diffs follows from inverting each inner diff history.
-
-### 4) Applying diffs with inverses: positivity and normality
-
-It is an unfortunate side effect of facilitating a `Group` instance for diffs
-that we can get into situations where applying diffs will fail or produce wrong
-results due to diffs containing internally unresolved sums and subtractions. The
-responsibility of downstream code is to ensure that diffs that are applied are
-both *positive* and *normal*. If that is the case, then applying diffs will
-never go wrong.
-
-* Positivity: a positive diff contains only `Insert`s and `Delete`s.
-* Normality: a normal diff has resolved all sums and subtrations internally,
-  i.e., there are no consecutive diff entries in a diff history that can still
-  be cancelled out.
-
-Please note: a positive diff is by definition also a normal diff. Normality is a
-weaker property than positivity. However, normality is a sufficient precondition
-for some definitions to work as expected (see the next paragraph), in which
-cases positivity would be an unnecessarily strong requirement.
-
-Normality is also a precondition for the type class laws to hold. This is an
-optimisation: we could normalise diff histories exhaustively in each sum or
-inversion operation, but that could be costly.
-
-If positivity and normality are guaranteed, then `applyDiff` will always return a `Right` result, and `unsafeApplyDiff` will never throw an error.
-
-```haskell
-applyDiff :: Ord k => Map k v -> Diff k v -> Either () (Map k v)
-unsafeApplyDiff :: Ord k => Map k v -> Diff k v -> Map k v
-```
-
-A number of definitions in the Haskell modules are annotated with PRECONDITION,
-INVARIANT and POSTCONDITION. Use these and the type class laws for `Semigroup`,
-`Monoid` and `Group` (which hold given preconditions) to ensure that applied
-diffs are always both positive and normal. This should not be too complex
-
-* Diffing maps creates diffs that are both positive and normal.
-* Summing preverses normality and positivity.
-* Empty diffs are both normal and positive.
-* Inversion preserves normality.
-* Subtraction preserves positivity if we only subtract diffs that we know are in
-  a sum. For example:
-
-  ```haskell
-  (d1 <> ... <> di <> dj <> ... <> dn) <> invert (dj <> ... <> dn) == d1 <> ... <> di
-  invert (d1 <> ... <> di) <> (d1 <> ... <> di <> dj <> ... <> dn) == dj <> ... <> dn
-  ```
-
-It is important to remember that these sum operations are not commutative.
-Summing/subtracting on the left is not the same as summing/subtracting on the
-right.

--- a/diff-containers/diff-containers.cabal
+++ b/diff-containers/diff-containers.cabal
@@ -27,7 +27,7 @@ library
   build-depends:
     , base                 >=4.9 && <4.17
     , containers
-    , groups
+    , monoid-subclasses
     , nonempty-containers
     , nothunks
 
@@ -47,13 +47,13 @@ test-suite test
     Test.Util
 
   build-depends:
-    , base                  >=4.9 && <4.17
+    , base                          >=4.9 && <4.17
     , containers
     , diff-containers
-    , groups
     , nonempty-containers
     , QuickCheck
-    , simple-semigroupoids
+    , quickcheck-classes
+    , quickcheck-monoid-subclasses
     , tasty
     , tasty-quickcheck
 

--- a/diff-containers/src/Data/Map/Diff/Strict.hs
+++ b/diff-containers/src/Data/Map/Diff/Strict.hs
@@ -1,28 +1,6 @@
 {-# OPTIONS_GHC -Wno-unused-imports #-}
 
--- | Differences on @'Map'@s with a @'Group'@ instance.
---
--- === Positivity and normality
---
--- It is an unfortunate side effect of facilitating a @'Group'@ instance for
--- @'Diff'@s that we can get into situations where applying diffs will fail or
--- produce wrong results due to diffs containing internally unresolved sums and
--- subtractions. The responsibility of downstream code is to ensure that diffs
--- that are applied are both /positive/ (@'isPositive'@) and /normal/
--- @('isNormal')@. If that is the case, then applying diffs will never go wrong.
---
--- * Positivity: a positive diff contains only Inserts and Deletes.
--- * Normality: a normal diff (i.e., a diff that is in normal form) has resolved
---   all sums and subtrations internally. This is the case if there are no
---   consecutive diff entries in a diff history that can still be cancelled out.
---
--- Note: a positive diff is by definition also a normal diff. Normality is a
--- weaker property than positivity.
---
--- A number of definitions in this modules are annotated with PRECONDITION,
--- INVARIANT and POSTCONDITION. Use these and the type class laws for
--- @'Semigroup'@, @'Monoid'@ and @'Group'@ (which hold given preconditions) to
--- ensure that applied diffs are always both positive and normal.
+-- | Differences on 'Map's, represented as asymmetrically cancellative monoids.
 module Data.Map.Diff.Strict (
     -- * Types
     Diff
@@ -43,9 +21,6 @@ module Data.Map.Diff.Strict (
     -- ** Size
   , null
   , size
-    -- ** Positivity and normality
-  , isNormal
-  , isPositive
     -- * Applying diffs
   , applyDiff
   , applyDiffForKeys
@@ -56,7 +31,6 @@ module Data.Map.Diff.Strict (
   , filterOnlyKey
   ) where
 
-import           Data.Group (Group)
 import           Data.Map.Diff.Strict.Internal
 import           Data.Map.Strict (Map)
 import           Prelude hiding (null)

--- a/diff-containers/src/Data/Map/Diff/Strict.hs
+++ b/diff-containers/src/Data/Map/Diff/Strict.hs
@@ -1,6 +1,6 @@
 {-# OPTIONS_GHC -Wno-unused-imports #-}
 
--- | Differences on 'Map's, represented as asymmetrically cancellative monoids.
+-- | Differences on 'Map's, represented as cancellative monoids.
 module Data.Map.Diff.Strict (
     -- * Types
     Diff

--- a/diff-containers/src/Data/Map/Diff/Strict/Internal.hs
+++ b/diff-containers/src/Data/Map/Diff/Strict/Internal.hs
@@ -134,15 +134,15 @@ diff m1 m2 = Diff $
 
 -- | @'fromMap' m@ creates a @'Diff'@ from the inserts and deletes in @m@.
 fromMap :: Map k (DiffEntry v) -> Diff k v
-fromMap = Diff . fmap singleton
+fromMap = Diff . Map.map singleton
 
 -- | @'fromMapInserts' m@ creates a @'Diff'@ that inserts all values in @m@.
 fromMapInserts :: Map k v -> Diff k v
-fromMapInserts = Diff . fmap singletonInsert
+fromMapInserts = Diff . Map.map singletonInsert
 
 -- | @'fromMapDeletes' m@ creates a @'Diff'@ that deletes all values in @m@.
 fromMapDeletes :: Map k v -> Diff k v
-fromMapDeletes = Diff . fmap singletonDelete
+fromMapDeletes = Diff . Map.map singletonDelete
 
 fromListDiffHistories :: Ord k => [(k, NEDiffHistory v)] -> Diff k v
 fromListDiffHistories = Diff . Map.fromList

--- a/diff-containers/src/Data/Map/Diff/Strict/Internal.hs
+++ b/diff-containers/src/Data/Map/Diff/Strict/Internal.hs
@@ -1,13 +1,10 @@
 {-# LANGUAGE DeriveAnyClass             #-}
+{-# LANGUAGE DeriveFunctor              #-}
 {-# LANGUAGE DeriveGeneric              #-}
-{-# LANGUAGE DeriveTraversable          #-}
 {-# LANGUAGE DerivingStrategies         #-}
-{-# LANGUAGE FlexibleInstances          #-}
 {-# LANGUAGE GeneralisedNewtypeDeriving #-}
-{-# LANGUAGE LambdaCase                 #-}
-{-# LANGUAGE Rank2Types                 #-}
-{-# LANGUAGE ScopedTypeVariables        #-}
-{-# LANGUAGE ViewPatterns               #-}
+{-# LANGUAGE InstanceSigs               #-}
+{-# LANGUAGE StandaloneDeriving         #-}
 
 -- | See the module documentation for "Data.Map.Diff.Strict".
 module Data.Map.Diff.Strict.Internal (
@@ -21,7 +18,6 @@ module Data.Map.Diff.Strict.Internal (
     -- ** Diff histories
   , nonEmptyDiffHistory
   , toDiffHistory
-  , unsafeFromDiffHistory
     -- * Construction
   , diff
     -- ** Maps
@@ -38,24 +34,15 @@ module Data.Map.Diff.Strict.Internal (
   , singletonDelete
   , singletonInsert
     -- * Deconstruction
+    -- ** Diff histories
   , last
     -- * Query
     -- ** Size
   , null
   , size
-    -- ** Positivity and normality
-  , isNormal
-  , isNormalDiffHistory
-  , isPositive
-  , isPositiveDiffHistory
-    -- * @'Group'@ instances
-  , areInverses
-  , invertDiffEntry
     -- * Applying diffs
   , applyDiff
   , applyDiffForKeys
-  , unsafeApplyDiff
-  , unsafeApplyDiffForKeys
     -- * Folds and traversals
   , foldMapDiffEntry
   , traverseDiffEntryWithKey_
@@ -64,14 +51,13 @@ module Data.Map.Diff.Strict.Internal (
   ) where
 
 import           Control.Monad (void)
-import           Data.Bifunctor
-import           Data.Either (fromRight)
-import           Data.Group
+import           Data.Bifunctor (Bifunctor (second))
 import qualified Data.Map.Merge.Strict as Merge
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
+import           Data.Semigroup.Cancellative (LeftCancellative,
+                     LeftReductive (..), RightCancellative, RightReductive (..))
 import           Data.Sequence (Seq (..))
-import qualified Data.Sequence as Seq
 import           Data.Sequence.NonEmpty (NESeq (..))
 import qualified Data.Sequence.NonEmpty as NESeq
 import           Data.Sequence.NonEmpty.Extra ()
@@ -108,12 +94,6 @@ newtype NEDiffHistory v = NEDiffHistory { getNEDiffHistory :: NESeq (DiffEntry v
 data DiffEntry v =
       Insert !v
     | Delete !v
-      -- | Considered unsafe to act on. Consider throwing an error when pattern
-      -- matching on this constructor.
-    | UnsafeAntiInsert !v
-      -- | Considered unsafe to act on. Consider throwing an error when pattern
-      -- matching on this constructor.
-    | UnsafeAntiDelete !v
   deriving stock (Generic, Show, Eq, Functor)
   deriving anyclass (NoThunks)
 
@@ -127,9 +107,6 @@ keysSet (Diff m) = Map.keysSet m
 toDiffHistory :: NEDiffHistory v -> DiffHistory v
 toDiffHistory (NEDiffHistory sq) = DiffHistory $ NESeq.toSeq sq
 
-unsafeFromDiffHistory :: DiffHistory v -> NEDiffHistory v
-unsafeFromDiffHistory (DiffHistory sq) = NEDiffHistory $ NESeq.unsafeFromSeq sq
-
 nonEmptyDiffHistory :: DiffHistory v -> Maybe (NEDiffHistory v)
 nonEmptyDiffHistory (DiffHistory sq) = NEDiffHistory <$> NESeq.nonEmptySeq sq
 
@@ -138,9 +115,6 @@ nonEmptyDiffHistory (DiffHistory sq) = NEDiffHistory <$> NESeq.nonEmptySeq sq
 ------------------------------------------------------------------------------}
 
 -- | Compute the difference between @'Map'@s.
---
--- POSTCONDITION: diffing computes a @'Diff'@ that is both normal and
--- positive.
 diff :: (Ord k, Eq v) => Map k v -> Map k v -> Diff k v
 diff m1 m2 = Diff $
     Merge.merge
@@ -199,7 +173,7 @@ singletonDelete = singleton . Delete
 ------------------------------------------------------------------------------}
 
 last :: NEDiffHistory v -> DiffEntry v
-last (getNEDiffHistory -> _ NESeq.:||> e) = e
+last (NEDiffHistory (_ NESeq.:||> e)) = e
 
 {------------------------------------------------------------------------------
   Query
@@ -211,220 +185,95 @@ null (Diff m) = Map.null m
 size :: Diff k v -> Int
 size (Diff m) = Map.size m
 
--- | A positive diff contains only @'Insert'@s and @'Delete'@s. A negative diff
--- can also contain @'UnsafeAntiInsert'@s and @'UnsafeAntiDelete'@s, which makes
--- applying diffs unsafe.
---
--- Note: a positive diff is by definition also a normal diff.
-isPositive :: Diff k v -> Bool
-isPositive (Diff m) = all (isPositiveDiffHistory . toDiffHistory) m
-
--- | Check if a diff history is positive, which means it can only contain
--- @'Insert'@s and @'Delete'@s.
---
--- Note: a positive diff history is by definition also a normal diff history.
-isPositiveDiffHistory :: DiffHistory v -> Bool
-isPositiveDiffHistory (DiffHistory vs) = all p vs
-  where
-    p (Insert _)           = True
-    p (Delete _)           = True
-    p (UnsafeAntiInsert _) = False
-    p (UnsafeAntiDelete _) = False
-
--- | A diff that is in normal form has resolved all sums and subtractions
--- internally. Applying a non-normal diff is considered unsafe.
-isNormal :: Eq v => Diff k v -> Bool
-isNormal (Diff d) = all (isNormalDiffHistory . toDiffHistory) d
-
--- | Check if a diff history is in normal form, where no succesive elements are
--- inverses of each other.
---
--- If two succesive diff entries are inverses, they can be cancelled out. In
--- other words, we can normalise the diff history further by cancelling out the
--- diff entries. If so, we can conclude that the input diff history is not in
--- normal form.
-isNormalDiffHistory :: Eq v => DiffHistory v -> Bool
-isNormalDiffHistory (DiffHistory vs) = case vs of
-  Empty     -> True
-  _ :<| des -> not $ any (uncurry areInverses) (Seq.zip vs des)
-
 {------------------------------------------------------------------------------
-  @'Group'@ instances
+  Instances
 ------------------------------------------------------------------------------}
 
--- | Summing of diffs.
---
--- PRECONDITION: Normality is required for type class laws to hold.
---
--- INVARIANT: Summing preserves both positivity and normality.
-instance (Ord k, Eq v) => Semigroup (Diff k v) where
-  Diff m1 <> Diff m2 = Diff $
-    Merge.merge
-      Merge.preserveMissing
-      Merge.preserveMissing
-      (Merge.zipWithMaybeMatched(\_k h1 h2 ->
-        nonEmptyDiffHistory (toDiffHistory h1 <> toDiffHistory h2)
-      ))
-      m1
-      m2
+instance Ord k => Semigroup (Diff k v) where
+  (<>) :: Diff k v -> Diff k v -> Diff k v
+  (Diff m1) <> (Diff m2) = Diff $ Map.unionWith (<>) m1 m2
 
--- | Identity diffs.
---
--- PRECONDITION: Normality is required for type class laws to hold.
---
--- INVARIANT: @'mempty'@ is both positive and normal.
-instance (Ord k, Eq v) => Monoid (Diff k v) where
+instance Ord k => Monoid (Diff k v) where
+  mempty :: Diff k v
   mempty = Diff mempty
 
--- | Inverting diffs.
---
--- PRECONDITION: Normality is required for type class laws to hold.
---
--- INVARIANT: @'invert'@ preserves normality.
-instance (Ord k, Eq v) => Group (Diff k v) where
-  invert (Diff m) = Diff $
-    fmap (unsafeFromDiffHistory . invert . toDiffHistory) m
-
--- | @h1 <> h2@ sums @h1@ and @h2@ by cancelling out as many consecutive diff
--- entries as possible, and appending the remainders.
---
--- PRECONDITION: Normality is required for type class laws to hold.
---
--- INVARIANT: Summing preserves both positivity and normality.
---
--- Diff entries that are each other's inverse (irrespective of their order) can
--- cancel out:
---
--- * @'UnsafeAntiInsert' x@ cancels out any @'Insert' y@ if @x == y@.
---
--- * @'UnsafeAntiDelete' x@ cancels out any @'Delete' y@ if @x == y@.
---
--- Note: We do not cancel out consecutive elements in @h1@ and @h2@
--- individually. It is only at the border between @h1@ and @h2@ that we cancel
--- out elements. This means that @'mappend'@ing two diff histories does not by
--- definition return a normal diff.
-instance Eq v => Semigroup (DiffHistory v) where
-  DiffHistory s1 <> DiffHistory s2 = DiffHistory $ s1 `mappend'` s2
+instance (Ord k, Eq v) => LeftReductive (Diff k v) where
+  stripPrefix :: Diff k v -> Diff k v -> Maybe (Diff k v)
+  stripPrefix (Diff m1) (Diff m2) = Diff <$>
+      Merge.mergeA
+        (Merge.traverseMissing $ \_ _ -> Nothing)
+        Merge.preserveMissing
+        (Merge.zipWithMaybeAMatched f)
+        m1
+        m2
     where
-      -- At the ``touching'' ends of the sequences, take off diff entries that
-      -- are each other's inverse until we find two non-inverse entries. In this
-      -- case, we can not continue so we return the concatenated remainders.
-      mappend' (xs :|> x) (y :<| ys)
-        | areInverses x y                    = mappend' xs ys
-      mappend' xs ys                         = xs Seq.>< ys
+      f _ h1 h2 = nonEmptyDiffHistory <$>
+          stripPrefix (toDiffHistory h1) (toDiffHistory h2)
 
--- | Identity diff histories.
---
--- PRECONDITION: Normality is required for type class laws to hold.
---
--- INVARIANT: @'mempty'@ is both positive and normal.
-instance Eq v => Monoid (DiffHistory v) where
-  mempty = DiffHistory mempty
+instance (Ord k, Eq v) => RightReductive (Diff k v) where
+  stripSuffix :: Diff k v -> Diff k v -> Maybe (Diff k v)
+  stripSuffix (Diff m1) (Diff m2) = Diff <$>
+      Merge.mergeA
+        (Merge.traverseMissing $ \_ _ -> Nothing)
+        Merge.preserveMissing
+        (Merge.zipWithMaybeAMatched f)
+        m1
+        m2
+    where
+      f _ h1 h2 = nonEmptyDiffHistory <$>
+          stripSuffix (toDiffHistory h1) (toDiffHistory h2)
 
--- | Inverting diff histories.
---
--- PRECONDITION: Normality is required for type class laws to hold.
---
--- INVARIANT: @'invert'@ preserves normality.
-instance Eq v => Group (DiffHistory v) where
-  invert (DiffHistory s) = DiffHistory $ Seq.reverse . fmap invertDiffEntry $ s
+instance (Ord k, Eq v) => LeftCancellative (Diff k v)
+instance (Ord k, Eq v) => RightCancellative (Diff k v)
 
--- | @`invertDiffEntry` e@ inverts a @'DiffEntry' e@ to its counterpart.
---
--- Note: We invert @'DiffEntry'@s, but a @'DiffEntry'@ is not a @'Group'@: we do
--- not have an identity element, so @'DiffEntry'@ is not a @'Monoid'@ or
--- @'Semigroup'@.
-invertDiffEntry :: DiffEntry v -> DiffEntry v
-invertDiffEntry = \case
-  Insert x           -> UnsafeAntiInsert x
-  Delete x           -> UnsafeAntiDelete x
-  UnsafeAntiInsert x -> Insert x
-  UnsafeAntiDelete x -> Delete x
+deriving newtype instance Semigroup (NEDiffHistory v)
 
--- | @'areInverses' e1 e2@ checks whether @e1@ and @e2@ are each other's
--- inverse.
-areInverses :: Eq v => DiffEntry v -> DiffEntry v -> Bool
-areInverses e1 e2 = invertDiffEntry e1 == e2
+deriving newtype instance Semigroup (DiffHistory v)
+deriving newtype instance Monoid (DiffHistory v)
+deriving newtype instance Eq v => LeftReductive (DiffHistory v)
+deriving newtype instance Eq v => RightReductive (DiffHistory v)
+deriving newtype instance Eq v => LeftCancellative (DiffHistory v)
+deriving newtype instance Eq v => RightCancellative(DiffHistory v)
 
 {------------------------------------------------------------------------------
   Applying diffs
 ------------------------------------------------------------------------------}
 
 -- | Applies a diff to a @'Map'@.
---
--- PRECONDITION: The diff that is to be applied is both normal and positive.
---
--- POSTCONDITION: The result is @'Right' m@ for some @m@.
 applyDiff ::
      Ord k
   => Map k v
   -> Diff k v
-  -> Either () (Map k v)
+  -> Map k v
 applyDiff m (Diff diffs) =
-    Merge.mergeA
+    Merge.merge
       Merge.preserveMissing
-      (Merge.traverseMaybeMissing newKeys)
-      (Merge.zipWithMaybeAMatched oldKeys)
+      (Merge.mapMaybeMissing newKeys)
+      (Merge.zipWithMaybeMatched oldKeys)
       m
       diffs
   where
-    newKeys :: k -> NEDiffHistory v -> Either () (Maybe v)
+    newKeys :: k -> NEDiffHistory v -> Maybe v
     newKeys _k h = case last h of
-      Insert x           -> Right $ Just x
-      Delete _           -> Right Nothing
-      UnsafeAntiInsert _ -> Left ()
-      UnsafeAntiDelete _ -> Left ()
+      Insert x -> Just x
+      Delete _ -> Nothing
 
-    oldKeys :: k -> v -> NEDiffHistory v -> Either () (Maybe v)
+    oldKeys :: k -> v -> NEDiffHistory v -> Maybe v
     oldKeys _k _v1 h = case last h of
-      Insert x           -> Right $ Just x
-      Delete _           -> Right Nothing
-      UnsafeAntiInsert _ -> Left ()
-      UnsafeAntiDelete _ -> Left ()
+      Insert x -> Just x
+      Delete _ -> Nothing
 
 -- | Applies a diff to a @'Map'@ for a specific set of keys.
---
--- PRECONDITION: The diff that is to be applied is both normal and positive.
---
--- POSTCONDITION: The result is @'Right' m@ for some @m@.
 applyDiffForKeys ::
      Ord k
   => Map k v
   -> Set k
   -> Diff k v
-  -> Either () (Map k v)
+  -> Map k v
 applyDiffForKeys m ks (Diff diffs) =
   applyDiff
     m
     (Diff $ diffs `Map.restrictKeys` (Map.keysSet m `Set.union` ks))
-
--- | Applies a diff to a @'Map'@, throws an error if applying the diff failed.
---
--- PRECONDITION: The diff that is to be applied is both normal and positive.
---
--- POSTCONDITION: No error is thrown.
-unsafeApplyDiff ::
-     Ord k
-  => Map k v
-  -> Diff k v
-  -> Map k v
-unsafeApplyDiff m d = fromRight (error "applyDiff failed") $
-  applyDiff m d
-
--- | Applies a diff to a @'Map'@ for a specific set of keys, throws an error if
--- applying the diff failed.
---
--- PRECONDITION: The diff that is to be applied is both normal and positive.
---
--- POSTCONDITION: No error is thrown.
-unsafeApplyDiffForKeys ::
-     Ord k
-  => Map k v
-  -> Set k
-  -> Diff k v
-  -> Map k v
-unsafeApplyDiffForKeys m s d = fromRight (error "applyDiffForKeys failed") $
-  applyDiffForKeys m s d
 
 {------------------------------------------------------------------------------
   Folds and traversals

--- a/diff-containers/test/Test/Data/Map/Diff/Strict.hs
+++ b/diff-containers/test/Test/Data/Map/Diff/Strict.hs
@@ -1,99 +1,54 @@
 {-# LANGUAGE DerivingStrategies         #-}
 {-# LANGUAGE GeneralisedNewtypeDeriving #-}
+{-# LANGUAGE NamedFieldPuns             #-}
 {-# LANGUAGE StandaloneDeriving         #-}
 {-# LANGUAGE TypeApplications           #-}
-{-# LANGUAGE ViewPatterns               #-}
 
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Test.Data.Map.Diff.Strict (tests) where
 
-import           Data.Either
-import           Data.Foldable
-import           Data.Group (Group (..))
-import           Data.Map.Diff.Strict.Internal hiding (null)
+import qualified Data.Map.Diff.Strict as Diff
+import           Data.Map.Diff.Strict.Internal (Diff (..), DiffEntry (..),
+                     DiffHistory (DiffHistory), NEDiffHistory (NEDiffHistory))
 import           Data.Map.Strict (Map)
 import           Data.Maybe
-import           Data.Proxy (Proxy (Proxy))
-import           Data.Semigroupoid.Simple.Laws
 import           Data.Sequence.NonEmpty (NESeq (..))
 import qualified Data.Sequence.NonEmpty as NESeq
+import           Data.Typeable
+import           Test.QuickCheck.Classes
+import           Test.QuickCheck.Classes.Semigroup.Cancellative
 import           Test.Tasty (TestTree, localOption, testGroup)
 import           Test.Tasty.QuickCheck hiding (Negative, Positive)
 import           Test.Util
 
 -- | Tests for "Data.Map.Diff.Strict".
 --
--- === The use of @'OftenSmall'@
---
--- Throughout these tests, we often use/test the @'Group'@ instances for
--- @'DiffHistory'@ and @'Diff'@. For @'mappend'@, @'mempty'@ and @'invert'@ to
--- do interesting things, we should generate values in a small range. Examples:
---
--- * An @'Insert' x@ and @'UnsafeAntiInsert' y@ can only cancel out if @x == y@.
--- If the range that we pick @x@ and @y@ from is large, then the probability
--- that @x == y@ is small.
---
--- * Only if two @'mappend'@ed diffs contain the same key will the corresponding
--- diff histories be @'mappend'@ed. If we pick keys in diffs from a large range,
--- then the probability of matching keys is low.
---
--- We use the @'OftenSmall'@ wrapper and its @'Arbitrary'@ instance to generate
--- small values often.
+-- Note: the laws from "Test.QuickCheck.Classes.Semigroup.Cancellative" are not
+-- affected by @'localOption' ('QuickCheckTests' n)@
 tests :: TestTree
 tests = testGroup "Data.Map.Diff.Strict" [
       localOption (QuickCheckTests 10000) $
-      testGroupWithProxy (Proxy @(NormalDiffHistory (OftenSmall Int))) [
-          testSemigroupLaws
-        , testMonoidLaws
-        , testGroupLaws
-        ]
-    , localOption (QuickCheckTests 1000) $
-      testGroupWithProxy (Proxy @(NormalDiff (OftenSmall Int) (OftenSmall Int))) [
-          testSemigroupLaws
-        , testMonoidLaws
-        , testGroupLaws
-        ]
-    , testGroup "Diffing" [
-          localOption (QuickCheckTests 10000) $
-          testProperty "prop_diffingIsPositive" $
-            prop_diffingIsPositive @(OftenSmall Int) @(OftenSmall Int)
-        , localOption (QuickCheckTests 10000) $
-          testProperty "prop_diffingIsNormal" $
-            prop_diffingIsNormal @(OftenSmall Int) @(OftenSmall Int)
-        ]
-    , localOption (QuickCheckTests 10000) $
-      testGroup "Positive implies normal" [
-          testProperty "prop_positiveDiffImpliesNormalDiff" $
-            prop_positiveDiffImpliesNormalDiff @(OftenSmall Int) @(OftenSmall Int)
-        , testProperty "prop_positiveDiffHistoryImpliesNormalDiffHistory" $
-            prop_positiveDiffHistoryImpliesNormalDiffHistory @(OftenSmall Int)
-        ]
-    , testGroup "Preserving positivity and normality" [
-          localOption (QuickCheckTests 1000) $
-          testProperty "prop_summingDiffsPreservesPositivity" $
-            prop_summingDiffsPreservesPositivity @(OftenSmall Int) @(OftenSmall Int)
-        , localOption (QuickCheckTests 10000) $
-          testProperty "prop_summingDiffHistoriesPreservesPositivity" $
-            prop_summingDiffHistoriesPreservesPositivity @(OftenSmall Int)
-        , localOption (QuickCheckTests 10000) $
-          testProperty "prop_summingDiffsPreservesNormality" $
-            prop_summingDiffsPreservesNormality @(OftenSmall Int) @(OftenSmall Int)
-        , localOption (QuickCheckTests 100000) $
-          testProperty "prop_summingDiffHistoriesPreservesNormality" $
-            prop_summingDiffHistoriesPreservesNormality @(OftenSmall Int)
-        , localOption (QuickCheckTests 10000) $
-          testProperty "prop_invertingDiffsPreservesNormality" $
-            prop_invertingDiffsPreservesNormality @(OftenSmall Int) @(OftenSmall Int)
-        , localOption (QuickCheckTests 100000) $
-          testProperty "prop_invertingDiffHistoriesPreservesNormality" $
-            prop_invertingDiffHistoriesPreservesNormality @(OftenSmall Int)
-        ]
-    , testGroup "Positivity and normality for identity elements" [
-          testProperty "prop_emptyDiffIsPositive" prop_emptyDiffIsPositive
-        , testProperty "prop_emptyDiffHistoryIsPositive" prop_emptyDiffHistoryIsPositive
-        , testProperty "prop_emptyDiffIsNormal" prop_emptyDiffIsNormal
-        , testProperty "prop_emptyDiffHistoryIsNormal" prop_emptyDiffHistoryIsNormal
+      testGroup "quickcheck-classes" [
+          lawsTestOne  (Proxy @(NEDiffHistory (OftenSmall Int))) [
+              semigroupLaws
+            ]
+        , lawsTestOne  (Proxy @(DiffHistory (OftenSmall Int))) [
+              semigroupLaws
+            , monoidLaws
+            , leftReductiveLaws
+            , rightReductiveLaws
+            , leftCancellativeLaws
+            , rightCancellativeLaws
+            ]
+        , lawsTestOne  (Proxy @(Diff (OftenSmall Int) (OftenSmall Int))) [
+              semigroupLaws
+            , monoidLaws
+            , leftReductiveLaws
+            , rightReductiveLaws
+            , leftCancellativeLaws
+            , rightCancellativeLaws
+            ]
         ]
     , testGroup "Applying diffs" [
           localOption (QuickCheckTests 10000) $
@@ -102,185 +57,27 @@ tests = testGroup "Data.Map.Diff.Strict" [
         , localOption (QuickCheckTests 10000) $
           testProperty "prop_applyMempty" $
             prop_applyMempty @(OftenSmall Int) @(OftenSmall Int)
-        , localOption (QuickCheckTests 100) $
+        , localOption (QuickCheckTests 1000) $
           testProperty "prop_applyAllAndApplySum" $
             prop_applyAllAndApplySum @(OftenSmall Int) @(OftenSmall Int)
-        , localOption (QuickCheckTests 1000) $
-          testProperty "prop_normalAndPositiveDiffsNeverFailApply" $
-            prop_normalAndPositiveDiffsNeverFailApply @(OftenSmall Int) @(OftenSmall Int)
-        , localOption (QuickCheckTests 1000) $
-          testProperty "prop_normalAndPositiveDiffsNeverFailUnsafeApply" $
-            prop_normalAndPositiveDiffsNeverFailUnsafeApply @(OftenSmall Int) @(OftenSmall Int)
-        ]
-    , testGroup "Generators" [
-          testGroup "All diffs and diff histories" [
-              testProperty "arbitrary/shrunk Diff is not always positive" $ expectFailure $
-                prop_arbitraryAndShrinkSatisfyProperty
-                  @(Diff (OftenSmall Int) (OftenSmall Int))
-                  isPositive
-            , testProperty "arbitrary/shrunk DiffHistory is not always positive" $ expectFailure $
-                prop_arbitrarySatisfiesProperty
-                  @(DiffHistory (OftenSmall Int))
-                  isPositiveDiffHistory
-            , testProperty "arbitrary/shrunk Diff is not always normal" $ expectFailure $
-                prop_arbitraryAndShrinkSatisfyProperty
-                  @(Diff (OftenSmall Int) (OftenSmall Int))
-                  isNormal
-            , testProperty "arbitrary/shrunk DiffHistory is not always normal" $ expectFailure $
-                prop_arbitrarySatisfiesProperty
-                  @(DiffHistory (OftenSmall Int))
-                  isNormalDiffHistory
-            ]
-        , testGroup "Normal diffs and diff histories" [
-              testProperty "arbitrary/shrunk NormalDiff is always in normal form" $
-                prop_arbitraryAndShrinkSatisfyProperty
-                  @(NormalDiff (OftenSmall Int) (OftenSmall Int))
-                  (isNormal . getNormalDiff)
-            , testProperty "arbitrary/shrunk NormalDiff is always in normal form" $
-                prop_arbitraryAndShrinkSatisfyProperty
-                  @(NormalDiffHistory (OftenSmall Int))
-                  (isNormalDiffHistory . getNormalDiffHistory)
-            ]
-        , testGroup "Positive diffs and diff histories" [
-              testProperty "arbitrary/shrunk PositiveDiff is always positive" $
-                prop_arbitraryAndShrinkSatisfyProperty
-                  @(PositiveDiff (OftenSmall Int) (OftenSmall Int))
-                  (isPositive . getPositiveDiff)
-            , testProperty "arbitrary/shrunk PositiveDiffHistory is always positive" $
-                prop_arbitraryAndShrinkSatisfyProperty
-                  @(PositiveDiffHistory (OftenSmall Int))
-                  (isPositiveDiffHistory . getPositiveDiffHistory)
-            , testProperty "arbitrary/shrunk PositiveDiff is always normal" $
-                prop_arbitraryAndShrinkSatisfyProperty
-                  @(PositiveDiff (OftenSmall Int) (OftenSmall Int))
-                  (isNormal . getPositiveDiff)
-            , testProperty "arbitrary/shrunk PositiveDiffHistory is always normal" $
-                prop_arbitraryAndShrinkSatisfyProperty
-                  @(PositiveDiffHistory (OftenSmall Int))
-                  (isNormalDiffHistory . getPositiveDiffHistory)
-            ]
         ]
     ]
 
 {------------------------------------------------------------------------------
-  Simple properties
+  Running laws in test trees
 ------------------------------------------------------------------------------}
 
--- | A @'Diff'@ computed from two @'Map'@s is positive.
-prop_diffingIsPositive ::
-     (Ord k, Eq v)
-  => Map k v
-  -> Map k v
-  -> Property
-prop_diffingIsPositive m1 m2 = property $ isPositive (diff m1 m2)
+lawsTest :: Laws -> TestTree
+lawsTest Laws{lawsTypeclass, lawsProperties} = testGroup lawsTypeclass $
+    fmap (uncurry testProperty) lawsProperties
 
--- | A @'Diff'@ computed from two @'Map'@s is normal.
-prop_diffingIsNormal ::
-     (Ord k, Eq v)
-  => Map k v
-  -> Map k v
-  -> Property
-prop_diffingIsNormal m1 m2 = property $ isNormal (diff m1 m2)
+lawsTestOne :: Typeable a => Proxy a -> [Proxy a -> Laws] -> TestTree
+lawsTestOne p tts =
+    testGroup (show $ typeOf p) (fmap (\f -> lawsTest $ f p) tts)
 
---
--- Positive implies normal
---
-
--- | A positive diff is implied to be normal.
-prop_positiveDiffImpliesNormalDiff ::
-     Eq v
-  => PositiveDiff k v
-  -> Property
-prop_positiveDiffImpliesNormalDiff (PositiveDiff d) =
-  property $ isNormal d
-
--- | A positive diff history is implied to be normal.
-prop_positiveDiffHistoryImpliesNormalDiffHistory ::
-     Eq v
-  => PositiveDiffHistory v
-  -> Property
-prop_positiveDiffHistoryImpliesNormalDiffHistory (PositiveDiffHistory h) =
-  property $ isNormalDiffHistory h
-
---
--- Preserving positivity and normality
---
-
--- | Test the invariant that summing @'Diff'@s preserves positivity.
-prop_summingDiffsPreservesPositivity ::
-     (Ord k, Eq v)
-  => PositiveDiff k v
-  -> PositiveDiff k v
-  -> Property
-prop_summingDiffsPreservesPositivity (PositiveDiff d1) (PositiveDiff d2) =
-  property $ isPositive (d1 <> d2)
-
--- | Test the invariant that summing @'DiffHistory'@s preserves positivity.
-prop_summingDiffHistoriesPreservesPositivity ::
-     Eq v
-  => PositiveDiffHistory v
-  -> PositiveDiffHistory v
-  -> Property
-prop_summingDiffHistoriesPreservesPositivity (PositiveDiffHistory h1) (PositiveDiffHistory h2) =
-  property $ isPositiveDiffHistory (h1 <> h2)
-
--- | Test the invariant that summing @'Diff'@s preserves normality.
-prop_summingDiffsPreservesNormality ::
-     (Ord k, Eq v)
-  => NormalDiff k v
-  -> NormalDiff k v
-  -> Property
-prop_summingDiffsPreservesNormality (NormalDiff d1) (NormalDiff d2) =
-  property $ isNormal (d1 <> d2)
-
--- | Test the invariant that summing @'DiffHistory'@s preserves normality.
-prop_summingDiffHistoriesPreservesNormality ::
-     Eq v
-  => NormalDiffHistory v
-  -> NormalDiffHistory v
-  -> Property
-prop_summingDiffHistoriesPreservesNormality (NormalDiffHistory h1) (NormalDiffHistory h2) =
-  property $ isNormalDiffHistory (h1 <> h2)
-
--- | Test the invariant that inverting @'Diff'@s preserves normality.
-prop_invertingDiffsPreservesNormality ::
-     (Ord k, Eq v)
-  => NormalDiff k v
-  -> Property
-prop_invertingDiffsPreservesNormality (NormalDiff d) =
-  property $ isNormal (invert d)
-
--- | Test the invariant that inverting @'DiffHistory'@s preserves normality.
-prop_invertingDiffHistoriesPreservesNormality ::
-     Eq v
-  => NormalDiffHistory v
-  -> Property
-prop_invertingDiffHistoriesPreservesNormality (NormalDiffHistory h) =
-  property $ isNormalDiffHistory (invert h)
-
---
--- Positivity and normality for identity elements
---
-
--- | Test the invariant that the identity @'Diff'@ element is positive.
-prop_emptyDiffIsPositive :: Property
-prop_emptyDiffIsPositive = once $ isPositive (mempty :: Diff Int Int)
-
--- | Test the invariant that the identity @'DiffHistory'@ element is positive.
-prop_emptyDiffHistoryIsPositive :: Property
-prop_emptyDiffHistoryIsPositive = once $ isPositiveDiffHistory (mempty :: DiffHistory Int)
-
--- | Test the invariant that the identity @'Diff'@ element is normal.
-prop_emptyDiffIsNormal :: Property
-prop_emptyDiffIsNormal = once $ isNormal (mempty :: Diff Int Int)
-
--- | Test the invariant that the identity @'DiffHistory'@ element is normal.
-prop_emptyDiffHistoryIsNormal:: Property
-prop_emptyDiffHistoryIsNormal = once $ isNormalDiffHistory (mempty :: DiffHistory Int)
-
---
--- Applying diffs
---
+{------------------------------------------------------------------------------
+  Applying diffs
+------------------------------------------------------------------------------}
 
 -- | Applying a @'Diff'@ computed from a source and target @'Map'@ should
 -- produce the target @'Map'@.
@@ -289,73 +86,24 @@ prop_diffThenApply ::
   => Map k v
   -> Map k v
   -> Property
-prop_diffThenApply m1 m2 = applyDiff m1 (diff m1 m2) === Right m2
+prop_diffThenApply m1 m2 = Diff.applyDiff m1 (Diff.diff m1 m2) === m2
 
 -- | Applying an empty @'Diff'@ is the identity function.
 prop_applyMempty ::
      (Show k, Show v, Ord k, Eq v)
   => Map k v
   -> Property
-prop_applyMempty m = applyDiff m mempty === Right m
+prop_applyMempty m = Diff.applyDiff m mempty === m
 
--- | Applying a sum of normal and positive @'Diff'@s is equivalent to applying
--- each (normal and positive) @'Diff'@ separately (in order).
+-- | Applying a sum of @'Diff'@s is equivalent to applying each @'Diff'@
+-- separately (in order).
 prop_applyAllAndApplySum ::
      (Show k, Show v, Ord k, Eq v)
   => Map k v
-  -> [PositiveDiff k v]
+  -> [Diff k v]
   -> Property
-prop_applyAllAndApplySum m (fmap getPositiveDiff -> ds) =
-  foldlM applyDiff m ds === applyDiff m (mconcat ds)
-
--- | Applying a diff that is both positive and normal will never fail.
-prop_normalAndPositiveDiffsNeverFailApply ::
-     Ord k
-  => Map k v
-  -> PositiveDiff k v
-  -> Property
-prop_normalAndPositiveDiffsNeverFailApply m (PositiveDiff d) =
-  property $ isRight (applyDiff m d)
-
--- | Unsafely applying a diff that is both positive and normal will never throw
--- an error.
-prop_normalAndPositiveDiffsNeverFailUnsafeApply ::
-     Ord k
-  => Map k v
-  -> PositiveDiff k v
-  -> Property
-prop_normalAndPositiveDiffsNeverFailUnsafeApply m (PositiveDiff d) =
-  property $ unsafeApplyDiff m d `seq` ()
-
---
--- Generators
---
-
--- | Check whether values generated by an @'Arbitrary'@ instance satisfy a
--- property.
-prop_arbitrarySatisfiesProperty ::
-     (Show a, Arbitrary a)
-  => (a -> Bool)
-  -> Property
-prop_arbitrarySatisfiesProperty p = forAll arbitrary (property . p)
-
--- | Check whether values shrunk by an @'Arbitrary'@ instance
--- satisfy a property.
-prop_shrinkSatisfiesProperty ::
-     (Show a, Arbitrary a)
-  => (a -> Bool)
-  -> Property
-prop_shrinkSatisfiesProperty p = forAll arbitrary (property . all p . shrink)
-
-
--- | Check whether values generated and shrunk by an @'Arbitrary'@ instance
--- satisfy a property.
-prop_arbitraryAndShrinkSatisfyProperty ::
-     (Show a, Arbitrary a)
-  => (a -> Bool)
-  -> Property
-prop_arbitraryAndShrinkSatisfyProperty p =
-  prop_arbitrarySatisfiesProperty p .&&. prop_shrinkSatisfiesProperty p
+prop_applyAllAndApplySum m ds =
+  foldl Diff.applyDiff m ds === Diff.applyDiff m (mconcat ds)
 
 {------------------------------------------------------------------------------
   Plain @'Arbitrary'@ instances
@@ -363,83 +111,18 @@ prop_arbitraryAndShrinkSatisfyProperty p =
 
 deriving newtype instance (Ord k, Arbitrary k, Arbitrary v)
                        => Arbitrary (Diff k v)
+deriving newtype instance Arbitrary v => Arbitrary (DiffHistory v)
 
 instance Arbitrary v => Arbitrary (NEDiffHistory v) where
   arbitrary = NEDiffHistory <$> ((:<||) <$> arbitrary <*> arbitrary)
   shrink (NEDiffHistory h) =
     fmap NEDiffHistory $ mapMaybe NESeq.nonEmptySeq $ shrink (NESeq.toSeq h)
 
-instance Arbitrary v => Arbitrary (DiffHistory v) where
-  arbitrary = DiffHistory <$> arbitrary
-  shrink (DiffHistory s) = DiffHistory <$> shrink s
-
 instance Arbitrary v => Arbitrary (DiffEntry v) where
   arbitrary = oneof [
       Insert <$> arbitrary
     , Delete <$> arbitrary
-    , UnsafeAntiInsert <$> arbitrary
-    , UnsafeAntiDelete <$> arbitrary
     ]
   shrink de = case de of
-    Insert x           -> Insert <$> shrink x
-    Delete x           -> Delete <$> shrink x
-    UnsafeAntiInsert x -> UnsafeAntiInsert <$> shrink x
-    UnsafeAntiDelete x -> UnsafeAntiDelete <$> shrink x
-
-{------------------------------------------------------------------------------
-  Modifiers: positivity
-------------------------------------------------------------------------------}
-
--- | A @'Diff'@ for which @'isPositive'@ holds.
-newtype PositiveDiff k v = PositiveDiff { getPositiveDiff :: Diff k v }
-  deriving stock (Show, Eq)
-  deriving newtype (Semigroup, Monoid, Group)
-
-instance (Ord k, Arbitrary k, Arbitrary v)
-      => Arbitrary (PositiveDiff k v) where
-  arbitrary =
-    PositiveDiff <$> arbitrary `suchThat` isPositive
-  shrink (PositiveDiff d) =
-    [PositiveDiff d' | d' <- shrink d, isPositive d']
-
--- | A @'DiffHistory'@ for which @'isPositiveDiffHistory'@ holds.
-newtype PositiveDiffHistory v = PositiveDiffHistory {
-    getPositiveDiffHistory :: DiffHistory v
-  }
-  deriving stock (Show, Eq)
-  deriving newtype (Semigroup, Monoid, Group)
-
-instance Arbitrary v => Arbitrary (PositiveDiffHistory v) where
-  arbitrary =
-    PositiveDiffHistory <$> arbitrary `suchThat` isPositiveDiffHistory
-  shrink (PositiveDiffHistory h) =
-    [PositiveDiffHistory h' | h' <- shrink h, isPositiveDiffHistory h']
-
-{------------------------------------------------------------------------------
-  Modifiers: normality
-------------------------------------------------------------------------------}
-
--- | A @'Diff'@ for which @'isNormal'@ holds.
-newtype NormalDiff k v = NormalDiff { getNormalDiff :: Diff k v }
-  deriving stock (Show, Eq)
-  deriving newtype (Semigroup, Monoid, Group)
-
-instance (Ord k, Eq v, Arbitrary k, Arbitrary v)
-      => Arbitrary (NormalDiff k v) where
-  arbitrary =
-    NormalDiff <$> arbitrary `suchThat` isNormal
-  shrink (NormalDiff d) =
-    [NormalDiff d' | d' <- shrink d, isNormal d']
-
--- | A @'DiffHistory'@ for which @'isNormalDiffHistory'@ holds.
-newtype NormalDiffHistory v = NormalDiffHistory {
-    getNormalDiffHistory :: DiffHistory v
-  }
-  deriving stock (Show, Eq)
-  deriving newtype (Semigroup, Monoid, Group)
-
-instance (Arbitrary v, Eq v) => Arbitrary (NormalDiffHistory v) where
-  arbitrary =
-    NormalDiffHistory <$> arbitrary `suchThat` isNormalDiffHistory
-  shrink (NormalDiffHistory h) =
-    [NormalDiffHistory h' | h' <- shrink h, isNormalDiffHistory h']
+    Insert x -> Insert <$> shrink x
+    Delete x -> Delete <$> shrink x

--- a/fingertree-rm/CHANGELOG.md
+++ b/fingertree-rm/CHANGELOG.md
@@ -1,5 +1,9 @@
+## Next version
 
-<a id='changelog-0.1.0.0'></a>
+### Breaking changes
+
+* Require a root measure to be a cancellative monoid instead of a group.
+
 ## 0.1.0.0 — 2023-02-16
 
 First release

--- a/fingertree-rm/README.md
+++ b/fingertree-rm/README.md
@@ -7,13 +7,12 @@ one implementation for strict finger trees.
 ## Finger trees with root measures
 
 A possible way to represent a sequence of monoidal sums of any monoid `v` is by
-means of a finger tree, where the leaves contain elements of type `a` that can be
-measured as `v`, and the intermediate nodes contain the cumulative sums of the
-leaves.
+means of a finger tree, where the leaves contain elements of type `a` that can
+be measured as `v`, and the intermediate nodes contain the cumulative sums of
+the leaves.
 
 ```haskell
 data StrictFingerTree v a = {- omitted -}
-
 
 class Monoid v ⇒ Measured v a | a → v where
   measure :: a -> v
@@ -57,10 +56,13 @@ data StrictFingerTree vr vi a = {- omitted -}
 ```
 
 It is clear from the `cons`/`tail` example above that we should be able to both
-sum and subtract root measures. So, we require a root measure to be a `Group`.
+sum and subtract root measures. So, we require a root measure to be a
+cancellative monoid, which provides a means for subtraction through the
+`stripPrefix` and `stripSuffix` functions.
 
 ```haskell
-class Group v => RootMeasured v a | a -> v where
+class (LeftCancellative v, RightCancellative v, Monoid v)
+   => RootMeasured v a | a -> v where
   measureRoot :: a -> v
 
 -- | All @'StrictFingerTree'@s are root measured.

--- a/fingertree-rm/bench/Bench/Data/FingerTree/RootMeasured/Strict.hs
+++ b/fingertree-rm/bench/Bench/Data/FingerTree/RootMeasured/Strict.hs
@@ -17,7 +17,6 @@ import qualified Data.FingerTree as FT
 import           Data.FingerTree.RootMeasured.Strict
 import qualified Data.FingerTree.Strict as SFT
 import           Data.Foldable
-import           Data.Group
 import           Data.Monoid
 import           Test.QuickCheck
 import           Test.Tasty (TestTree, testGroup)
@@ -97,7 +96,6 @@ newtype Length = Length {unLength :: Int}
 
 deriving via Sum Int instance Semigroup Length
 deriving via Sum Int instance Monoid Length
-deriving via Sum Int instance Group Length
 
 instance Measured Length Int where
   measure _ = Length 1

--- a/fingertree-rm/fingertree-rm.cabal
+++ b/fingertree-rm/fingertree-rm.cabal
@@ -23,7 +23,7 @@ library
   build-depends:
     , base                       >=4.9 && <4.17
     , cardano-strict-containers
-    , groups
+    , monoid-subclasses
     , nothunks
 
   ghc-options:

--- a/fingertree-rm/fingertree-rm.cabal
+++ b/fingertree-rm/fingertree-rm.cabal
@@ -63,7 +63,6 @@ benchmark bench
     , deepseq
     , fingertree
     , fingertree-rm
-    , groups
     , QuickCheck
     , tasty
     , tasty-bench

--- a/fingertree-rm/src/Data/FingerTree/RootMeasured/Strict.hs
+++ b/fingertree-rm/src/Data/FingerTree/RootMeasured/Strict.hs
@@ -81,8 +81,7 @@ instance Measured vi a => Measured vi (StrictFingerTree vr vi a) where
 --
 -- > instance Measured T' a where -- ...
 --
--- Furthermore, we want the root measure to be an asymmetrically cancellative
--- monoid.
+-- Furthermore, we want the root measure to be an cancellative monoid.
 class (LeftCancellative v, RightCancellative v, Monoid v)
    => RootMeasured v a | a -> v where
   measureRoot :: a -> v
@@ -127,9 +126,9 @@ fromList !xs = SFT (foldMap measureRoot xs) (FT.fromList xs)
 -- i.e. that the predicate is /monotonic/.
 --
 -- A @'SplitRootMeasure'@ function @f@ should be provided that computes the root
--- measures of the left and right parts of the split. Since the @vr@ type is an
--- asymetrically cancellative monoid, we can use 'stripPrefix' and 'stripSuffix'
--- to compute the root measures: see @'splitl'@ and @'splitr'@.
+-- measures of the left and right parts of the split. Since the @vr@ type is a
+-- cancellative monoid, we can use 'stripPrefix' and 'stripSuffix' to compute
+-- the root measures: see @'splitl'@ and @'splitr'@.
 --
 -- Note on time complexity: the @log@ factor comes from @'FT.split'@. Moreover,
 -- the @log@ factor of the time complexity is determined by the smallest part of

--- a/fingertree-rm/src/Data/FingerTree/RootMeasured/Strict.hs
+++ b/fingertree-rm/src/Data/FingerTree/RootMeasured/Strict.hs
@@ -30,8 +30,10 @@ module Data.FingerTree.RootMeasured.Strict (
 
 import           Data.FingerTree.Strict (Measured)
 import qualified Data.FingerTree.Strict as FT
-import           Data.Foldable
-import           Data.Group
+import           Data.Foldable (Foldable (toList))
+import           Data.Maybe (fromJust)
+import           Data.Semigroup.Cancellative (LeftCancellative,
+                     LeftReductive (..), RightCancellative, RightReductive (..))
 import           GHC.Generics (Generic)
 import           NoThunks.Class (NoThunks (..), noThunksInValues)
 
@@ -79,9 +81,10 @@ instance Measured vi a => Measured vi (StrictFingerTree vr vi a) where
 --
 -- > instance Measured T' a where -- ...
 --
--- Furthermore, we want the root measure to be a @'Group'@ instead of a
--- @'Monoid'@.
-class Group v => RootMeasured v a | a -> v where
+-- Furthermore, we want the root measure to be an asymmetrically cancellative
+-- monoid.
+class (LeftCancellative v, RightCancellative v, Monoid v)
+   => RootMeasured v a | a -> v where
   measureRoot :: a -> v
 
 -- | All @'StrictFingerTree'@s are root measured.
@@ -124,9 +127,9 @@ fromList !xs = SFT (foldMap measureRoot xs) (FT.fromList xs)
 -- i.e. that the predicate is /monotonic/.
 --
 -- A @'SplitRootMeasure'@ function @f@ should be provided that computes the root
--- measures of the left and right parts of the split. Since the @vr@ type has a
--- @'Group'@ instance, we can use the inversion operation from the @'Group'@
--- class to compute the root measures: see @'splitl'@ and @'splitr'@.
+-- measures of the left and right parts of the split. Since the @vr@ type is an
+-- asymetrically cancellative monoid, we can use 'stripPrefix' and 'stripSuffix'
+-- to compute the root measures: see @'splitl'@ and @'splitr'@.
 --
 -- Note on time complexity: the @log@ factor comes from @'FT.split'@. Moreover,
 -- the @log@ factor of the time complexity is determined by the smallest part of
@@ -177,7 +180,7 @@ splitl ::
      )
 splitl p = split p $ SplitRootMeasure $ \vr (l, _r) ->
   let vrl = foldMap measureRoot l
-  in  (vrl, invert vrl <> vr)
+  in  (vrl, fromJust $ stripPrefix vrl vr)
 
 -- | /O(log(min(i,n-i))) + O(n-i)/. Specialisation of @'split'@ that is fast if
 -- if @i@ is large.
@@ -190,7 +193,7 @@ splitr ::
      )
 splitr p = split p $ SplitRootMeasure $ \vr (_l, r) ->
   let vrr = foldMap measureRoot r
-  in  (vr <> invert vrr, vrr)
+  in  (fromJust $ stripSuffix vrr vr, vrr)
 
 class Sized a where
   size :: a -> Int
@@ -214,10 +217,10 @@ splitSized p = split p $ SplitRootMeasure $ \vr (l, r) ->
   in
     if sizel <= sizer then
       let vrl = foldMap measureRoot l
-      in  (vrl, invert vrl <> vr)
+      in  (vrl, fromJust $ stripPrefix vrl vr)
     else
       let vrr = foldMap measureRoot r
-      in  (vr ~~ vrr, vrr)
+      in  (fromJust $ stripSuffix vrr vr, vrr)
 
 {-------------------------------------------------------------------------------
   Maps

--- a/scripts/format-stylish.sh
+++ b/scripts/format-stylish.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
 PARGS="-p ."
 CARGS=""
 
@@ -13,8 +15,6 @@ do
 done
 
 echo "Running stylish-haskell script with arguments: $PARGS $CARGS"
-
-set -euo pipefail
 
 export LC_ALL=C.UTF-8
 


### PR DESCRIPTION
Currently, we provide `Group` instance for `Diff`s. However, this comes with the caveat that downstream code has to preserve some invariants while manipulating `Diff`s, lest the downstream code runs into errors. I recently came across four types of asymmetric `Semigroup`-like type classes that could replace the `Group` instance. This makes the code simpler, and removes the need for preserving invariants. These classes are provided in [the `monoid-subclasses` package](https://hackage.haskell.org/package/monoid-subclasses-1.2.3/docs/Data-Semigroup-Cancellative.html#g:2):

* The `LeftReductive` and `RightReductive` type classes extend a `Semigroup` with a partial left-inverse (`stripPrefix`) and partial right-inverse (`stripSuffix`). 
* The `LeftCancellative` and `RightCancellative` type classes offers no new class functions, but do include the type class laws that the `stripPrefix` and `stripSuffix` are total.

`stripPrefix` and `stripSuffix` are exactly sufficient for our use case. When we manipulate sequences (root-measured fingertrees) of diffs, stripping prefixes and stripping suffixes is all we need to update root measures. See the `split*` functions in `Data.FingerTree.RootMeasured.Strict`.