### PR TITLE
Count number of inserts and deletes for a diff

### DIFF
--- a/diff-containers/src/Data/Map/Diff/Strict.hs
+++ b/diff-containers/src/Data/Map/Diff/Strict.hs
@@ -20,6 +20,8 @@ module Data.Map.Diff.Strict (
     -- * Query
     -- ** Size
   , null
+  , numDeletes
+  , numInserts
   , size
     -- * Applying diffs
   , applyDiff


### PR DESCRIPTION
Motivated by [ouroboros-network#39](https://github.com/input-output-hk/ouroboros-consensus/issues/57). Counting the number of inserts and deletes in a diff helps us in of the UTxO in ouroboros-consensus. This is because in the UTxO HD era, information about the size of the UTxO is not readily available anymore in memory, but has to be computed from on-disk and in-memory information, the latter of which consists largely of diffs.
