### PR TITLE
Fix laziness in the `Functor` instance for `Diff`.

### DIFF
--- a/diff-containers/CHANGELOG.md
+++ b/diff-containers/CHANGELOG.md
@@ -1,3 +1,9 @@
+## next version
+
+### Patch
+
+* Fix laziness in the `Functor` instance for `Diff`.
+
 ## 1.0.1.0 — 2023-05-11
 
 * Add `numInserts` and `numDeletes` to count a diff's number of inserts and

--- a/diff-containers/src/Data/Map/Diff/Strict/Internal.hs
+++ b/diff-containers/src/Data/Map/Diff/Strict/Internal.hs
@@ -77,8 +77,13 @@ import           Prelude hiding (last, length, null, splitAt)
 
 -- | A diff for key-value stores.
 newtype Diff k v = Diff (Map k (NEDiffHistory v))
-  deriving stock (Generic, Show, Eq, Functor)
+  deriving stock (Generic, Show, Eq)
   deriving anyclass (NoThunks)
+
+-- | Custom 'Functor' instance, since @'Functor' ('Map' k)@ is actually the
+-- 'Functor' instance for a lazy Map.
+instance Functor (Diff k) where
+  fmap f (Diff m) = Diff $ Map.map (fmap f) m
 
 -- | A history of changes to a value in a key-value store.
 --


### PR DESCRIPTION
The standard `Functor` instance for `Data.Map` is actually lazy. This PR replaces the automatically derived `Functor` instance for `Diff` with an explicit implementation that uses the strict `map` function.