### PR TITLE
Repository maintenance, make packages build with `ghc-9.8`

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,0 +1,123 @@
+# Sources
+# * https://github.com/haskell-actions/setup/tree/v2/?tab=readme-ov-file#model-cabal-workflow-with-caching
+# * https://github.com/actions/starter-workflows/blob/main/pages/static.yml
+# * https://haskell-haddock.readthedocs.io/en/latest/multi-components.html
+# * https://github.com/IntersectMBO/ouroboros-consensus/blob/main/.github/workflows/ci.yml
+# * https://github.com/IntersectMBO/ouroboros-consensus/blob/main/scripts/docs/haddocks.sh
+#
+name: Documentation
+
+on:
+  push:
+    branches: [ "main" ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+
+  build-documentation:
+    name: Build documentation
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+
+    env:
+      ghc: "9.6.4"
+      cabal: "3.10.2.1"
+      os: ubuntu-latest"
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    - name: Setup Haskell
+      id: setup-haskell
+      uses: haskell-actions/setup@v2
+      with:
+        ghc-version: ${{ env.ghc }}
+        cabal-version: ${{ env.cabal }}
+        cabal-update: true
+
+    - name: Configure the build
+      run: |
+        cabal configure --disable-tests --disable-benchmarks --enable-documentation
+        cabal build all --dry-run
+      # The last step generates dist-newstyle/cache/plan.json for the cache key.
+
+    - name: Cache cabal store
+      uses: actions/cache@v3
+      env:
+        cache-name: ${{ runner.os }}-${{ env.ghc }}-documentation-cabal-store
+      with:
+        path: ${{ steps.setup-haskell.outputs.cabal-store }}
+        key: ${{ env.cache-name }}-${{ hashFiles('**/plan.json') }}
+        restore-keys: |
+          ${{ env.cache-name }}-${{ hashFiles('**/plan.json') }}
+          ${{ env.cache-name }}-
+
+    - name: Build haddocks
+      run: |
+        ./scripts/haddocks.sh
+        tar vzcf haddocks.tgz ./docs/haddocks
+
+    - name: Upload haddocks as an artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: haddocks
+        path: haddocks.tgz
+        retention-days: 1
+
+
+  deploy-documentation:
+    name: Deploy documentation to GitHub Pages
+
+    needs: build-documentation
+
+    runs-on: ubuntu-latest
+
+    strategy:
+        fail-fast: false
+
+    # https://github.com/actions/deploy-pages
+    permissions:
+      pages: write
+      id-token: write
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v3
+
+      - name: Download haddocks artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: haddocks
+
+      - name: Unpack haddocks artifact
+        run: |
+          tar vzxf haddocks.tgz
+
+      - name: Upload haddocks artifact to pages
+        uses: actions/upload-pages-artifact@v2
+        with:
+          path: ./docs/haddocks
+
+      - name: Deploy to GitHub pages
+        id: deployment
+        uses: actions/deploy-pages@v2

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -4,20 +4,26 @@ on:
   push:
     branches: [ "main" ]
   pull_request:
+  merge_group:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 
 permissions:
   contents: read
 
 jobs:
+  # Build and test
   build:
-
     runs-on: ${{ matrix.os }}
 
     strategy:
       fail-fast: false
       matrix:
-        ghc: ["8.10.7", "9.2.8", "9.4.5", "9.6.2"]
-        cabal: ["3.10.1.0"]
+        ghc: ["8.10.7", "9.2.8", "9.4.8", "9.6.4", "9.8.2"]
+        cabal: ["3.10.2.1"]
         os: [ubuntu-latest, windows-latest, macOS-latest]
 
     steps:
@@ -26,44 +32,55 @@ jobs:
 
     - name: Setup Haskell
       id: setup-haskell
-      uses: haskell/actions/setup@v2
+      uses: haskell-actions/setup@v2
       with:
         ghc-version: ${{ matrix.ghc }}
         cabal-version: ${{ matrix.cabal }}
-        cabal-update: false
+        cabal-update: true
 
-    - name: "Configure cabal.project.local"
+    - name: Configure the build
       run: |
-        cp .github/workflows/cabal.project.local.haskell cabal.project.local
-
-    - name: Cabal update
-      run: cabal update
+        cabal configure --enable-tests --enable-benchmark --ghc-options="-Werror" --ghc-options="-fno-ignore-asserts"
+        cat cabal.project.local
 
     - name: Record cabal dependencies
       id: record-deps
       run: |
         cabal build all --dry-run
 
-    - name: Cache cabal store
-      uses: actions/cache@v3
+    - name: "Restore cache"
+      uses: actions/cache/restore@v4
+      id: restore-cabal-cache
       env:
         cache-name: cache-cabal-build
       with:
         path: ${{ steps.setup-haskell.outputs.cabal-store }}
         key: ${{ runner.os }}-${{ matrix.ghc }}-${{ env.cache-name }}-${{ hashFiles('**/*.cabal') }}-${{ hashFiles('**/cabal.project') }}
         restore-keys: |
+          ${{ runner.os }}-${{ matrix.ghc }}-${{ env.cache-name }}-${{ hashFiles('**/*.cabal') }}-${{ hashFiles('**/cabal.project') }}
+          ${{ runner.os }}-${{ matrix.ghc }}-${{ env.cache-name }}-${{ hashFiles('**/*.cabal') }}-
           ${{ runner.os }}-${{ matrix.ghc }}-${{ env.cache-name }}-
-          ${{ runner.os }}-${{ matrix.ghc }}-
-          ${{ runner.os }}-
 
     - name: Install cabal dependencies
+      id: build-dependencies
       run: cabal build --only-dependencies --enable-tests --enable-benchmarks all
 
+    - name: "Save cache"
+      uses: actions/cache/save@v4
+      id: save-cabal-cache
+      # Note: cache-hit will be set to true only when cache hit occurs for the
+      # exact key match. For a partial key match via restore-keys or a cache
+      # miss, it will be set to false.
+      if: steps.build-dependencies.outcome == 'success' && steps.restore-cabal-cache.outputs.cache-hit != 'true'
+      with:
+        path: ${{ steps.setup-haskell.outputs.cabal-store }}
+        key:  ${{ steps.restore-cabal-cache.outputs.cache-primary-key }}
+
     - name: Build
-      run: cabal build --enable-tests --enable-benchmarks all
+      run: cabal build all
 
     - name: Run tests
-      run: cabal test all
+      run: cabal test -j1 --test-show-details=direct all
 
   # Check formatting for Haskell files
   stylish-haskell:
@@ -72,8 +89,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ["9.2.8"]
-        cabal: ["3.10.1.0"]
+        ghc: ["9.6.4"]
+        cabal: ["3.10.2.1"]
         os: [ubuntu-latest]
 
     steps:
@@ -87,7 +104,7 @@ jobs:
 
     - name: Setup Haskell
       id: setup-haskell
-      uses: haskell/actions/setup@v2
+      uses: haskell-actions/setup@v2
       with:
         ghc-version: ${{ matrix.ghc }}
         cabal-version: ${{ matrix.cabal }}
@@ -105,14 +122,10 @@ jobs:
         cache-name: cache-cabal-stylish
       with:
         path: ${{ steps.setup-haskell.outputs.cabal-store }}
-        key: ${{ runner.os }}-${{ matrix.ghc }}-${{ env.cache-name }}-${{ hashFiles('**/*.cabal') }}-${{ hashFiles('**/cabal.project') }}
-        restore-keys: |
-          ${{ runner.os }}-${{ matrix.ghc }}-${{ env.cache-name }}-
-          ${{ runner.os }}-${{ matrix.ghc }}-
-          ${{ runner.os }}-
+        key: ${{ runner.os }}-${{ matrix.ghc }}-${{ env.cache-name }}
 
     - name: Install stylish-haskell
-      run: cabal install stylish-haskell --constraint 'stylish-haskell == 0.14.4.0'
+      run: cabal install --ignore-project stylish-haskell --constraint 'stylish-haskell == 0.14.6.0'
 
     - name: Record stylish-haskell version
       run: |
@@ -131,8 +144,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ["9.2.8"]
-        cabal: ["3.10.1.0"]
+        ghc: ["9.6.4"]
+        cabal: ["3.10.2.1"]
         os: [ubuntu-latest]
 
     steps:
@@ -146,7 +159,7 @@ jobs:
 
     - name: Setup Haskell
       id: setup-haskell
-      uses: haskell/actions/setup@v2
+      uses: haskell-actions/setup@v2
       with:
         ghc-version: ${{ matrix.ghc }}
         cabal-version: ${{ matrix.cabal }}
@@ -164,14 +177,10 @@ jobs:
         cache-name: cache-cabal-cabal-fmt
       with:
         path: ${{ steps.setup-haskell.outputs.cabal-store }}
-        key: ${{ runner.os }}-${{ matrix.ghc }}-${{ env.cache-name }}-${{ hashFiles('**/*.cabal') }}-${{ hashFiles('**/cabal.project') }}
-        restore-keys: |
-          ${{ runner.os }}-${{ matrix.ghc }}-${{ env.cache-name }}-
-          ${{ runner.os }}-${{ matrix.ghc }}-
-          ${{ runner.os }}-
+        key: ${{ runner.os }}-${{ matrix.ghc }}-${{ env.cache-name }}
 
     - name: Install cabal-fmt
-      run: cabal install cabal-fmt --constraint 'cabal-fmt == 0.1.6'
+      run: cabal install --ignore-project cabal-fmt --constraint 'cabal-fmt == 0.1.11'
 
     - name: Record cabal-fmt version
       run: |
@@ -182,3 +191,33 @@ jobs:
       run: |
         ./scripts/format-cabal.sh
         git diff --exit-code
+
+  # Check cabal files
+  cabal-check:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        ghc: ["9.6.4"]
+        cabal: ["3.10.2.1"]
+        os: [ubuntu-latest]
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    - name: Setup Haskell
+      id: setup-haskell
+      uses: haskell-actions/setup@v2
+      with:
+        ghc-version: ${{ matrix.ghc }}
+        cabal-version: ${{ matrix.cabal }}
+        cabal-update: false
+
+    - name: Cabal update
+      run: cabal update
+
+    - name: Run cabal check
+      run: |
+        ./scripts/check-cabal.sh

--- a/.stylish-haskell.yaml
+++ b/.stylish-haskell.yaml
@@ -1,5 +1,3 @@
-# Copied from https://github.com/input-output-hk/ouroboros-consensus/blob/e19a58d078b882e5180d9ef591a1f4e9a1987fe0/.stylish-haskell.yaml
-#
 # Stylish-haskell configuration file used for the Consensus layer
 # It's based on default config provided by `stylish-haskell --defaults` but has some changes
 # ==================================
@@ -23,16 +21,16 @@ steps:
   # Currently, this option is not configurable and will format all exports and
   # module declarations to minimize diffs
   #
-  - module_header:
+  #- module_header:
   #     # How many spaces use for indentation in the module header.
-       indent: 2
+  #     indent: 2
   #
   #     # Should export lists be sorted?  Sorting is only performed within the
   #     # export section, as delineated by Haddock comments.
-       sort: true
+  #     sort: False
   #
   #     # See `separate_lists` for the `imports` step.
-       separate_lists: true
+  #     separate_lists: true
   #
   #     # When to break the "where".
   #     # Possible values:
@@ -42,14 +40,14 @@ steps:
   #     #   determined by the `columns` setting. Not applicable when the export
   #     #   list contains comments as newlines will be required.
   #     # - always: always break before the "where".
-       break_where: single
+  #     break_where: single
   #
   #     # Where to put open bracket
   #     # Possible values:
   #     # - same_line: put open bracket on the same line as the module name, before the
   #     #              comment of the module
   #     # - next_line: put open bracket on the next line, after module comment
-       open_bracket: same_line
+  #     open_bracket: same_line
 
   # Format record definitions. This is disabled by default.
   #
@@ -328,7 +326,7 @@ steps:
       #   > import Control.Monad.MonadError
       #
       # Default: false
-      group_imports: true
+      group_imports: false
 
       # A list of rules specifying how to group modules and how to
       # order the groups.

--- a/NOTICE
+++ b/NOTICE
@@ -1,4 +1,4 @@
-Copyright 2022-2023 Input Output (Hong Kong) Ltd.
+Copyright 2022-2024 Input Output Global Inc (IOG).
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/diff-containers/CHANGELOG.md
+++ b/diff-containers/CHANGELOG.md
@@ -1,3 +1,9 @@
+## next release — ????-??-??
+
+### Patch
+
+* Make it build with `ghc-9.8`.
+
 ## 1.1.1.0 — 2023-08-01
 
 ### Non-breaking changes

--- a/diff-containers/NOTICE
+++ b/diff-containers/NOTICE
@@ -1,4 +1,4 @@
-Copyright 2022-2023 Input Output (Hong Kong) Ltd.
+Copyright 2022-2024 Input Output Global Inc (IOG).
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/diff-containers/diff-containers.cabal
+++ b/diff-containers/diff-containers.cabal
@@ -13,7 +13,7 @@ author:        Joris Dral
 maintainer:    operations@iohk.io, Joris Dral (joris@well-typed.com)
 category:      Data Structures
 build-type:    Simple
-tested-with:   GHC ==8.10 || ==9.2 || ==9.4 || ==9.6
+tested-with:   GHC ==8.10 || ==9.2 || ==9.4 || ==9.6 || ==9.8
 
 library
   default-language: Haskell2010
@@ -24,7 +24,7 @@ library
 
   other-modules:    Data.Sequence.NonEmpty.Extra
   build-depends:
-    , base                 >=4.9 && <4.19
+    , base                 >=4.9 && <4.20
     , containers
     , monoid-subclasses
     , nonempty-containers
@@ -46,7 +46,7 @@ test-suite test
     Test.Util
 
   build-depends:
-    , base                          >=4.9 && <4.19
+    , base                          >=4.9 && <4.20
     , containers
     , diff-containers
     , nonempty-containers

--- a/diff-containers/diff-containers.cabal
+++ b/diff-containers/diff-containers.cabal
@@ -2,16 +2,15 @@ cabal-version: 3.0
 name:          diff-containers
 version:       1.1.1.0
 synopsis:      Diffs for containers
-
--- description:
+description:   Diffs for containers.
 license:       Apache-2.0
 license-files:
   LICENSE
   NOTICE
 
-copyright:     2022-2023 Input Output (Hong Kong) Ltd.
+copyright:     2022-2023 Input Output Global Inc (IOG).
 author:        Joris Dral
-maintainer:    operations@iohk.io
+maintainer:    operations@iohk.io, Joris Dral (joris@well-typed.com)
 category:      Data Structures
 build-type:    Simple
 tested-with:   GHC ==8.10 || ==9.2 || ==9.4 || ==9.6

--- a/fingertree-rm/CHANGELOG.md
+++ b/fingertree-rm/CHANGELOG.md
@@ -1,3 +1,9 @@
+## next release — ????-??-??
+
+### Patch
+
+* Make it build with `ghc-9.8`.
+
 ## 1.0.0.1 — 2023-07-14
 
 ### Patch

--- a/fingertree-rm/NOTICE
+++ b/fingertree-rm/NOTICE
@@ -1,4 +1,4 @@
-Copyright 2022-2023 Input Output (Hong Kong) Ltd.
+Copyright 2022-2024 Input Output Global Inc (IOG).
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/fingertree-rm/fingertree-rm.cabal
+++ b/fingertree-rm/fingertree-rm.cabal
@@ -13,14 +13,14 @@ author:        Joris Dral
 maintainer:    operations@iohk.io, Joris Dral (joris@well-typed.com)
 category:      Data Structures
 build-type:    Simple
-tested-with:   GHC ==8.10 || ==9.2 || ==9.4 || ==9.6
+tested-with:   GHC ==8.10 || ==9.2 || ==9.4 || ==9.6 || ==9.8
 
 library
   default-language: Haskell2010
   hs-source-dirs:   src
   exposed-modules:  Data.FingerTree.RootMeasured.Strict
   build-depends:
-    , base                       >=4.9 && <4.19
+    , base                       >=4.9 && <4.20
     , cardano-strict-containers
     , monoid-subclasses
     , nothunks
@@ -38,7 +38,7 @@ test-suite test
   main-is:          Main.hs
   other-modules:    Test.Data.FingerTree.RootMeasured.Strict
   build-depends:
-    , base              >=4.9 && <4.19
+    , base              >=4.9 && <4.20
     , fingertree-rm
     , tasty
     , tasty-quickcheck
@@ -56,7 +56,7 @@ benchmark bench
   main-is:          Main.hs
   other-modules:    Bench.Data.FingerTree.RootMeasured.Strict
   build-depends:
-    , base                       >=4.9 && <4.19
+    , base                       >=4.9 && <4.20
     , cardano-strict-containers
     , deepseq
     , fingertree

--- a/fingertree-rm/fingertree-rm.cabal
+++ b/fingertree-rm/fingertree-rm.cabal
@@ -2,16 +2,15 @@ cabal-version: 3.0
 name:          fingertree-rm
 version:       1.0.0.1
 synopsis:      Finger-trees with root measures
-
--- description:
+description:   Finger-trees with root measures.
 license:       Apache-2.0
 license-files:
   LICENSE
   NOTICE
 
-copyright:     2022-2023 Input Output (Hong Kong) Ltd.
+copyright:     2022-2024 Input Output Global Inc (IOG).
 author:        Joris Dral
-maintainer:    operations@iohk.io
+maintainer:    operations@iohk.io, Joris Dral (joris@well-typed.com)
 category:      Data Structures
 build-type:    Simple
 tested-with:   GHC ==8.10 || ==9.2 || ==9.4 || ==9.6

--- a/scripts/haddocks.sh
+++ b/scripts/haddocks.sh
@@ -1,0 +1,142 @@
+#!/bin/bash
+#
+# This script is based on https://github.com/IntersectMBO/ouroboros-consensus/blob/4ff9aa5596598bb3681864b830c8a33e294d9bfe/scripts/docs/haddocks.sh
+#
+# Build haddock documentation and an index for all projects in the `lsm-tree`
+# repository.
+#
+# usage:
+# ./scripts/haddocks.sh directory [true|false]
+#
+# $1 - where to put the generated pages, this directory contents will be wiped
+#      out (so don't pass `/` or `./` - the latter will delete your 'dist-newstyle')
+#      (the default is './haddocks')
+# $2 - whether to re-build haddocks with `cabal haddock` command or a component name
+#      (the default is true)
+# $3 - cabal build directory
+#      (the default is "dist-newstyle")
+# $4 - include documentation for sub-libraries
+#      (the default is true)
+# $5 - include documentation for test suites
+#      (the default is false)
+# $6 - include documentation for benchmark suites
+#      (the default is false)
+
+set -euo pipefail
+
+OUTPUT_DIR=${1:-"./docs/haddocks"}
+REGENERATE=${2:-"true"}
+BUILD_DIR=${3:-"dist-newstyle"}
+INCLUDE_SUBLIBS=${4:-"true"}
+INCLUDE_TESTS=${5:-"false"}
+INCLUDE_BENCHMARKS=${6:-"false"}
+
+# the directory containing this script
+SCRIPTS_DIR=$(realpath $(dirname $(realpath $0)))
+
+GHC_VERSION=$(ghc --numeric-version)
+OS_ARCH="$(cat dist-newstyle/cache/plan.json | jq -r '.arch + "-" + .os' | head -n 1 | xargs)"
+
+# we don't include `--use-index` option, because then quickjump data is not
+# generated.  This is not ideal, but there is no way to generate only top level
+# `doc-index.html` file.  With this approach we get:
+# * `doc-index.json` and `doc-index.html` per package
+# * we can generate top level `doc-index.json` (which will only work at the top
+#   level).
+# * we could ammend package level `doc-index.json` files, but it's enough ...
+#   this should be fixed upstream.
+HADDOCK_OPTS=(
+    --builddir "${BUILD_DIR}"
+    --disable-optimization
+    --haddock-all
+    --haddock-internal
+    --haddock-html
+    --haddock-quickjump
+    --haddock-hyperlink-source
+    --haddock-option "--show-all"
+    --haddock-option "--use-unicode"
+  )
+
+# build documentation of all modules
+if [ ${REGENERATE} == "true" ]; then
+  cabal haddock "${HADDOCK_OPTS[@]}" all
+elif [ ${REGENERATE} != "false" ]; then
+  cabal haddock "${HADDOCK_OPTS[@]}" ${REGENERATE}
+fi
+
+if [[ !( -d ${OUTPUT_DIR} ) ]]; then
+  mkdir -p ${OUTPUT_DIR}
+fi
+
+# make all files user writable
+chmod -R u+w "${OUTPUT_DIR}"
+
+# copy the new docs
+for dir in $(ls "${BUILD_DIR}/build/${OS_ARCH}/ghc-${GHC_VERSION}"); do
+  package=$(echo "${dir}" | sed 's/-[0-9]\+\(\.[0-9]\+\)*//')
+  cp -r "${BUILD_DIR}/build/${OS_ARCH}/ghc-${GHC_VERSION}/${dir}/noopt/doc/html/${package}" ${OUTPUT_DIR}
+  # copy test packages documentation when it exists
+  if [ ${INCLUDE_TESTS} == "true" ] && [ -d "${BUILD_DIR}/build/${OS_ARCH}/ghc-${GHC_VERSION}/${dir}/t" ]; then
+      for test_package in $(ls "${BUILD_DIR}/build/${OS_ARCH}/ghc-${GHC_VERSION}/${dir}/t"); do
+          if [ -d "${BUILD_DIR}/build/${OS_ARCH}/ghc-${GHC_VERSION}/${dir}/t/${test_package}/noopt/doc/html/${package}/${test_package}" ]; then
+              cp -r "${BUILD_DIR}/build/${OS_ARCH}/ghc-${GHC_VERSION}/${dir}/t/${test_package}/noopt/doc/html/${package}/${test_package}" "${OUTPUT_DIR}/${package}-${test_package}"
+          fi
+      done
+  fi
+  # copy benchmark packages documentation when it exists
+  if [ ${INCLUDE_BENCHMARKS} == "true" ] && [ -d "${BUILD_DIR}/build/${OS_ARCH}/ghc-${GHC_VERSION}/${dir}/b" ]; then
+      for bench_package in $(ls "${BUILD_DIR}/build/${OS_ARCH}/ghc-${GHC_VERSION}/${dir}/b"); do
+          if [ -d "${BUILD_DIR}/build/${OS_ARCH}/ghc-${GHC_VERSION}/${dir}/b/${bench_package}/noopt/doc/html/${package}/${bench_package}" ]; then
+              cp -r "${BUILD_DIR}/build/${OS_ARCH}/ghc-${GHC_VERSION}/${dir}/b/${bench_package}/noopt/doc/html/${package}/${bench_package}" "${OUTPUT_DIR}/${package}-${bench_package}"
+          fi
+      done
+  fi
+  # copy sublib documentation when it exists
+  if [ ${INCLUDE_SUBLIBS} == "true" ] && [ -d "${BUILD_DIR}/build/${OS_ARCH}/ghc-${GHC_VERSION}/${dir}/l" ]; then
+      for sublib in $(ls "${BUILD_DIR}/build/${OS_ARCH}/ghc-${GHC_VERSION}/${dir}/l"); do
+          if [ -d "${BUILD_DIR}/build/${OS_ARCH}/ghc-${GHC_VERSION}/${dir}/l/${sublib}/noopt/doc/html/${package}" ]; then
+              cp -r "${BUILD_DIR}/build/${OS_ARCH}/ghc-${GHC_VERSION}/${dir}/l/${sublib}/noopt/doc/html/${package}" "${OUTPUT_DIR}/${package}-${sublib}"
+          fi
+      done
+  fi
+done
+
+
+# --read-interface options
+interface_options () {
+    for package in $(ls "${OUTPUT_DIR}"); do
+        if [[ -d "${OUTPUT_DIR}/${package}" ]]; then
+            # take the first haddock file found.
+            # there should be only one but the filename is the name of the main pacakage
+            # and can differ from the name of the enclosing directory
+            haddock_file=$(ls -1 ${OUTPUT_DIR}/${package}/*.haddock | head -1)
+            echo "--read-interface=${package},${haddock_file}"
+        fi
+  done
+}
+
+# Generate top level index using interface files
+#
+haddock \
+  -o ${OUTPUT_DIR} \
+  --title "anti-diffs" \
+  --package-name "anti-diffs" \
+  --gen-index \
+  --gen-contents \
+  --quickjump \
+  $(interface_options)
+
+# Assemble a toplevel `doc-index.json` from package level ones.
+#
+echo "[]" > "${OUTPUT_DIR}/doc-index.json"
+for file in $(ls $OUTPUT_DIR/*/doc-index.json); do
+  project=$(basename $(dirname $file));
+  jq -s \
+    ".[0] + [.[1][] | (. + {link: (\"${project}/\" + .link)}) ]" \
+    "${OUTPUT_DIR}/doc-index.json" \
+    ${file} \
+    > /tmp/doc-index.json
+  mv /tmp/doc-index.json "${OUTPUT_DIR}/doc-index.json"
+done
+
+echo "Generated documentation in ${OUTPUT_DIR}"


### PR DESCRIPTION
# Description

* stylish-haskell no longer formats the module header
* stylish-haskell no longer groups imports
* Updated copyright information
* `haddocks.sh` script for generating multi-package, local documentation
* Upload documentation to github pages
* Update GHA build+test workflow
* Add GHA job for `cabal check`
* Make it build with `ghc-9.8`

# Checklist

- [x] Document and test your changes.
- [x] Update documentation such as `README.md` files.
- [x] Changes introduced by the PR should be recorded in the relevant
  `CHANGELOG.md` files.
- [x] Link issues that the PR resolves (if any).